### PR TITLE
Add discovery iterators, AsAPIError, and basic-token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ifunny-go
 
-Go bindings for reading the iFunny HTTP + chat APIs.
-
-Full API reference on pkg.go.dev: **[`ifunny-go`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go)** · [`compose`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/compose) · [`bot`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/bot)
+Go bindings for reading the iFunny HTTP + chat APIs. API reference on pkg.go.dev: **[`ifunny-go`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go)** · [`compose`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/compose) · [`bot`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/bot)
 
 ## Install
 
@@ -41,20 +39,14 @@ func main() {
 }
 ```
 
-For an authenticated client (chat, personalized feeds, `Self`), pass a bearer token to `ifunny.MakeClient` instead. Iterators over feeds, comments, users, and chat channels live as `Iter*` methods on `*Client` and `*Chat`.
-
-See [`examples/`](examples/) for more, including chat.
-
-## Scope
-
-Started as an auth-only helper and grew to cover the HTTP surface and the chat WAMP layer — this repo now supersedes [`open-ifunny/discovery-bot`](https://github.com/open-ifunny/discovery-bot).
+For an authenticated client (chat, personalized feeds, `Self`), pass a bearer token to `ifunny.MakeClient` instead. Iterators over feeds, comments, users, and chat channels live as `Iter*` methods on `*Client` and `*Chat`. See [`examples/`](examples/) for more.
 
 ## TODO
 - [x] Move over the chat library code from [discovery-bot](https://github.com/open-ifunny/discovery-bot)
 - [x] Move over the feed scouring code from psyduck-etl/ifunny
 - [x] Basic crawling: content (feeds, explore, timelines), users, comments
-- [ ] Migrate iteration channels to Go 1.23+ range-over-func iterators (Go now has first-class iterators; replace the current `chan Result[T]` streaming shape)
+- [ ] Migrate iteration channels to Go 1.23+ range-over-func iterators + replace the current `chan Result[T]` streaming shape
 
 ## Thanks
 
-- [@makeshiftartist](https://github.com/makeshiftartist) for the basic-auth token algorithm in [ifunny.ts](https://github.com/makeshiftartist/ifunny.ts), ported into [`basic.go`](basic.go).
+- [@makeshiftartist](https://github.com/makeshiftartist) for the basic-auth research + impl in [`iFunny.ts`](https://github.com/makeshiftartist/ifunny.ts)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,60 @@
-## TODO
-- [x] move over the chat library code from [discovery-bot](https://github.com/open-ifunny/discovery-bot)
-- [ ] move over the feed scouring code from psyduck-etl/ifunny
-- [ ] basic crawling stuff: getting content ( from feeds, explore, timelines ), observe users, comments
-- [ ] channels for streaming crawl-able content ( think iterators from the node library ), using golang-set `Iterator`s might make sense here
+# ifunny-go
 
-## Not TODO 
-- auth - supply your own basic / bearer token 
-- writable api - might accept patches, but this intends to be primarily a read-only package 
-- extra features - this library only aims to support core iFunny features
+Go bindings for reading the iFunny HTTP + chat APIs.
+
+Full API reference on pkg.go.dev: **[`ifunny-go`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go)** · [`compose`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/compose) · [`bot`](https://pkg.go.dev/github.com/open-ifunny/ifunny-go/bot)
+
+## Install
+
+```
+go get github.com/open-ifunny/ifunny-go
+```
+
+## Quickstart
+
+Anonymous, read-only client via a minted basic token:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/open-ifunny/ifunny-go"
+	"github.com/open-ifunny/ifunny-go/compose"
+)
+
+func main() {
+	basic, _ := ifunny.GenerateBasic()
+	ua := ifunny.Android{Version: "14"}.UserAgent()
+
+	client, _ := ifunny.MakeClientBasic(basic, ua)
+	if err := client.PrimeBasic(); err != nil { // ~15s server-side wait
+		panic(err)
+	}
+
+	u, err := client.GetUser(compose.UserByNick("woof"))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s (%s)\n", u.Nick, u.ID)
+}
+```
+
+For an authenticated client (chat, personalized feeds, `Self`), pass a bearer token to `ifunny.MakeClient` instead. Iterators over feeds, comments, users, and chat channels live as `Iter*` methods on `*Client` and `*Chat`.
+
+See [`examples/`](examples/) for more, including chat.
+
+## Scope
+
+Started as an auth-only helper and grew to cover the HTTP surface and the chat WAMP layer — this repo now supersedes [`open-ifunny/discovery-bot`](https://github.com/open-ifunny/discovery-bot).
+
+## TODO
+- [x] Move over the chat library code from [discovery-bot](https://github.com/open-ifunny/discovery-bot)
+- [x] Move over the feed scouring code from psyduck-etl/ifunny
+- [x] Basic crawling: content (feeds, explore, timelines), users, comments
+- [ ] Migrate iteration channels to Go 1.23+ range-over-func iterators (Go now has first-class iterators; replace the current `chan Result[T]` streaming shape)
+
+## Thanks
+
+- [@makeshiftartist](https://github.com/makeshiftartist) for the basic-auth token algorithm in [ifunny.ts](https://github.com/makeshiftartist/ifunny.ts), ported into [`basic.go`](basic.go).

--- a/basic.go
+++ b/basic.go
@@ -32,19 +32,18 @@ func GenerateBasic() (string, error) {
 	return base64.StdEncoding.EncodeToString([]byte(a + hex.EncodeToString(sum[:]))), nil
 }
 
-// PrimeBasic activates a basic token: one GET /counters authenticated with the
-// token as Basic auth, then the server-side ~15s wait. Call once before first
-// use of a freshly generated token.
-func PrimeBasic(basic, userAgent string) error {
+// PrimeBasic activates the basic token this client was constructed with: one
+// GET /counters, then the server-side ~15s wait. Call once on a freshly
+// generated token before making other requests. Uses the client's configured
+// *http.Client, so any custom transport/timeouts are honored.
+func (client *Client) PrimeBasic() error {
 	req, err := http.NewRequest("GET", apiRoot+"/counters", nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("authorization", "Basic "+basic)
-	req.Header.Set("user-agent", userAgent)
-	req.Header.Set("ifunny-project-id", projectID)
+	req.Header = client.header()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.http.Do(req)
 	if err != nil {
 		return err
 	}

--- a/basic.go
+++ b/basic.go
@@ -16,7 +16,97 @@ import (
 const (
 	basicClientID     = "MsOIJ39Q28"
 	basicClientSecret = "PTDc3H8a)Vi=UYap"
+
+	// APP_VERSION and APP_BUILD identify the iFunny mobile app release
+	// we impersonate in the user-agent. Pinned to values from
+	// makeshiftartist/ifunny.ts. These will go stale as iFunny ships
+	// new builds; treat as a maintenance point rather than a stable API.
+	APP_VERSION = "8.15.1"
+	APP_BUILD   = "1130736"
 )
+
+// UserAgent is anything that renders itself to an iFunny user-agent
+// string. Both device profiles (Android, IOS) and caller-supplied raw
+// strings (RawUserAgent) satisfy this. Client constructors accept a
+// UserAgent so callers can either use the built-in device abstraction
+// or supply their own.
+type UserAgent interface {
+	String() string
+}
+
+// RawUserAgent is a caller-supplied user-agent string that satisfies
+// the UserAgent interface unchanged. Use this when you want full
+// control over the UA (e.g. reading it from configuration or an
+// environment variable).
+type RawUserAgent string
+
+// String returns the raw user-agent string.
+func (r RawUserAgent) String() string { return string(r) }
+
+// Phone models a mobile device the client pretends to be. iFunny is a
+// mobile app whose backend gates behavior on the user-agent, so any
+// caller-generated UA needs to look like a real phone. Implementations
+// own their OS name, OS version, brand, and model strings, and render
+// themselves into a UserAgent via UserAgent().
+type Phone interface {
+	OS() string        // "Android", "iOS"
+	OSVersion() string // caller-supplied, e.g. "14", "17.5.1"
+	Brand() string     // e.g. "google", "Apple"
+	Model() string     // e.g. "Pixel 8", "iPhone 15 Pro"
+
+	UserAgent() UserAgent
+}
+
+// Android models a Google Pixel 8 running the caller-supplied Android
+// version. Version is a free-form string (e.g. "14", "15") so new
+// releases don't require an SDK update.
+type Android struct{ Version string }
+
+// OS returns "Android".
+func (a Android) OS() string { return "Android" }
+
+// OSVersion returns the Android version supplied by the caller.
+func (a Android) OSVersion() string { return a.Version }
+
+// Brand returns "google".
+func (a Android) Brand() string { return "google" }
+
+// Model returns "Pixel 8".
+func (a Android) Model() string { return "Pixel 8" }
+
+// UserAgent returns a user-agent string for this Android device.
+func (a Android) UserAgent() UserAgent { return renderPhoneUA(a) }
+
+// IOS models an iPhone 15 Pro running the caller-supplied iOS version.
+// Version is a free-form string (e.g. "17.5.1", "18.0") so new releases
+// don't require an SDK update.
+type IOS struct{ Version string }
+
+// OS returns "iOS".
+func (i IOS) OS() string { return "iOS" }
+
+// OSVersion returns the iOS version supplied by the caller.
+func (i IOS) OSVersion() string { return i.Version }
+
+// Brand returns "Apple".
+func (i IOS) Brand() string { return "Apple" }
+
+// Model returns "iPhone 15 Pro".
+func (i IOS) Model() string { return "iPhone 15 Pro" }
+
+// UserAgent returns a user-agent string for this iOS device.
+func (i IOS) UserAgent() UserAgent { return renderPhoneUA(i) }
+
+// renderPhoneUA renders a Phone into the iFunny app's UA template:
+//
+//	iFunny/{APP_VERSION}({APP_BUILD}) {OS}/{OSVersion} ({Brand}; {Model}; {Brand})
+func renderPhoneUA(p Phone) UserAgent {
+	return RawUserAgent(fmt.Sprintf("iFunny/%s(%s) %s/%s (%s; %s; %s)",
+		APP_VERSION, APP_BUILD,
+		p.OS(), p.OSVersion(),
+		p.Brand(), p.Model(), p.Brand(),
+	))
+}
 
 // GenerateBasic mints a fresh, unprimed basic token, mirroring the iFunny
 // app's client-side algorithm (the length-112 variant):

--- a/basic.go
+++ b/basic.go
@@ -1,0 +1,59 @@
+package ifunny
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	basicClientID     = "MsOIJ39Q28"
+	basicClientSecret = "PTDc3H8a)Vi=UYap"
+)
+
+// GenerateBasic mints a fresh, unprimed basic token, mirroring the iFunny
+// app's client-side algorithm (the length-112 variant):
+//
+//	token = base64( HEX + "_" + id + ":" + sha1hex(HEX + ":" + id + ":" + secret) )
+//
+// where HEX is an uppercased, dash-stripped random UUID.
+func GenerateBasic() (string, error) {
+	id := strings.ToUpper(strings.ReplaceAll(uuid.NewString(), "-", ""))
+	a := id + "_" + basicClientID + ":"
+	b := id + ":" + basicClientID + ":" + basicClientSecret
+	sum := sha1.Sum([]byte(b))
+	return base64.StdEncoding.EncodeToString([]byte(a + hex.EncodeToString(sum[:]))), nil
+}
+
+// PrimeBasic activates a basic token: one GET /counters authenticated with the
+// token as Basic auth, then the server-side ~15s wait. Call once before first
+// use of a freshly generated token.
+func PrimeBasic(basic, userAgent string) error {
+	req, err := http.NewRequest("GET", apiRoot+"/counters", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("authorization", "Basic "+basic)
+	req.Header.Set("user-agent", userAgent)
+	req.Header.Set("ifunny-project-id", projectID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("prime basic token: HTTP %d", resp.StatusCode)
+	}
+
+	time.Sleep(15 * time.Second)
+	return nil
+}

--- a/basic_integration_test.go
+++ b/basic_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package ifunny
+
+import (
+	"os"
+	"testing"
+
+	"github.com/open-ifunny/ifunny-go/compose"
+)
+
+// integrationNickEnv names the environment variable that supplies the
+// nickname used to exercise GetUser during integration tests.
+const integrationNickEnv = "IFUNNY_INTEGRATION_NICK"
+
+// TestBasicFlow exercises the full unauthenticated path
+// (GenerateBasic -> MakeClientBasic -> PrimeBasic -> GetUser by_nick)
+// against the live iFunny API for both the Android and iOS device
+// profiles. It is gated behind the `integration` build tag and
+// includes PrimeBasic's ~15s server-side wait per subtest, so it is
+// not part of the default `go test` run.
+//
+// The target nickname must be provided via the IFUNNY_INTEGRATION_NICK
+// environment variable.
+//
+// Invoke deliberately with:
+//
+//	IFUNNY_INTEGRATION_NICK=woof go test -tags=integration -run TestBasicFlow -v
+func TestBasicFlow(t *testing.T) {
+	nick := os.Getenv(integrationNickEnv)
+	if nick == "" {
+		t.Fatalf("%s must be set to run integration tests", integrationNickEnv)
+	}
+
+	cases := []struct {
+		name string
+		ua   UserAgent
+	}{
+		{"android", Android{Version: "14"}.UserAgent()},
+		{"ios", IOS{Version: "17.5.1"}.UserAgent()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("user-agent: %s", tc.ua.String())
+
+			basic, err := GenerateBasic()
+			if err != nil {
+				t.Fatalf("GenerateBasic: %v", err)
+			}
+			if basic == "" {
+				t.Fatal("GenerateBasic returned empty token")
+			}
+			t.Logf("minted basic token (len=%d)", len(basic))
+
+			client, err := MakeClientBasic(basic, tc.ua)
+			if err != nil {
+				t.Fatalf("MakeClientBasic: %v", err)
+			}
+
+			t.Log("priming (this takes ~15s)")
+			if err := client.PrimeBasic(); err != nil {
+				t.Fatalf("PrimeBasic: %v", err)
+			}
+
+			user, err := client.GetUser(compose.UserByNick(nick))
+			if err != nil {
+				t.Fatalf("GetUser(by_nick %s): %v", nick, err)
+			}
+
+			if user.ID == "" {
+				t.Fatal("user has empty ID")
+			}
+			if user.Nick == "" {
+				t.Fatal("user has empty Nick")
+			}
+			t.Logf("fetched user: nick=%s id=%s", user.Nick, user.ID)
+		})
+	}
+}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -22,11 +22,11 @@ type Bot struct {
 	handleEvents map[string]filtHandler
 }
 
-func MakeBot(bearer, userAgent string) (*Bot, error) {
+func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(ifunny.LogLevel)
-	client, err := ifunny.MakeClientLog(bearer, userAgent, log)
+	client, err := ifunny.MakeClientLog(bearer, ua, log)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (bot *Bot) Subscribe(channel string) {
 		unsub()
 	}
 
-	bot.Chat.Subscribe(compose.EventsIn(channel), func(eventType int, eventKW map[string]interface{}) error {
+	bot.Chat.Subscribe(compose.EventsIn(channel), func(eventType int, eventKW map[string]any) error {
 		log = log.WithFields(logrus.Fields{"event_type": eventType, "channel": channel})
 		log.Trace("handle event")
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -26,7 +26,7 @@ func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(ifunny.LogLevel)
-	client, err := ifunny.MakeClientLog(bearer, ua, log)
+	client, err := ifunny.MakeClient(bearer, ua, ifunny.WithLogger(log))
 	if err != nil {
 		return nil, err
 	}

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ChatChannel represents a direct message or group chat channel. It includes the channel
+// name, title, member counts, and metadata about the current user's role and membership status.
 type ChatChannel struct {
 	Name          string `json:"name"`
 	Title         string `json:"title"`
@@ -26,6 +28,7 @@ type ChatChannel struct {
 	} `json:"user"`
 }
 
+// ChatChannelPage wraps a paginated response of chat channels and a count.
 type ChatChannelPage struct {
 	Channels struct {
 		Items  []*ChatChannel `json:"items"`
@@ -35,14 +38,14 @@ type ChatChannelPage struct {
 }
 
 func (chat *Chat) handleChannelsRaw(handle func(eventType int, channel *ChatChannel) error) EventHandler {
-	return func(eventType int, kwargs map[string]interface{}) error {
+	return func(eventType int, kwargs map[string]any) error {
 		log := chat.client.log.WithFields(logrus.Fields{"event_type": eventType, "kwargs": kwargs})
 
 		switch eventType {
 		case EVENT_JOIN, EVENT_INVITED:
 			log.Trace("handle channel joined")
 
-			for _, channelRaw := range kwargs["chats"].([]interface{}) {
+			for _, channelRaw := range kwargs["chats"].([]any) {
 				channel := new(ChatChannel)
 				if err := JSONDecode(channelRaw, channel); err != nil {
 					return err
@@ -69,14 +72,19 @@ func (chat *Chat) handleChannelsRaw(handle func(eventType int, channel *ChatChan
 	}
 }
 
+// OnChannelUpdate subscribes to channel join and invite events. The handler is called
+// with the event type and channel data. Returns an unsubscribe function.
 func (chat *Chat) OnChannelUpdate(handle func(eventType int, channel *ChatChannel) error) (func(), error) {
 	return chat.Subscribe(compose.JoinedChannels(chat.client.Self.ID), chat.handleChannelsRaw(handle))
 }
 
+// OnChannelInvite subscribes to channel invite events. The handler is called with the
+// event type and invited channel data. Returns an unsubscribe function.
 func (chat *Chat) OnChannelInvite(handle func(eventType int, channel *ChatChannel) error) (func(), error) {
 	return chat.Subscribe(compose.ReceiveInvite(chat.client.Self.ID), chat.handleChannelsRaw(handle))
 }
 
+// GetChannel executes a chat RPC call and unmarshals the result as a ChatChannel.
 func (chat *Chat) GetChannel(call turnpike.Call) (*ChatChannel, error) {
 	output := new(struct {
 		Chat *ChatChannel `json:"chat"`
@@ -86,6 +94,7 @@ func (chat *Chat) GetChannel(call turnpike.Call) (*ChatChannel, error) {
 	return output.Chat, err
 }
 
+// GetChannels fetches all chat channels matching the given request.
 func (client *Client) GetChannels(desc compose.Request) ([]*ChatChannel, error) {
 	output := new(struct {
 		Data struct {
@@ -97,6 +106,8 @@ func (client *Client) GetChannels(desc compose.Request) ([]*ChatChannel, error) 
 	return output.Data.Channels, err
 }
 
+// GetChannelsPage fetches a single page of chat channels given a composed request.
+// It is used internally by channel iteration methods and exported for advanced use cases.
 func (client *Client) GetChannelsPage(desc compose.Request) (*Page[ChatChannel], error) {
 	output := new(struct {
 		Data struct {
@@ -107,12 +118,16 @@ func (client *Client) GetChannelsPage(desc compose.Request) (*Page[ChatChannel],
 	return &output.Data.Channels, err
 }
 
+// IterChannelsQuery returns a channel that yields chat channels matching a search query.
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterChannelsQuery(query string) <-chan Result[*ChatChannel] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.ChatsQuery(query, limit, page)
 	}, client.GetChannelsPage)
 }
 
+// DMChannelName constructs a direct message channel name from the authenticated user's ID
+// and one or more recipient user IDs.
 func (client *Client) DMChannelName(them ...string) string {
 	return compose.DMChannelName(client.Self.ID, them)
 }

--- a/chat-message.go
+++ b/chat-message.go
@@ -7,16 +7,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Message type constants for chat events.
 const (
-	UNK_0 messageType = iota
-	TEXT_MESSAGE
-	UNK_2
-	JOIN_CHANNEL
-	EXIT_CHANNEL
+	UNK_0        messageType = iota // Unknown type 0
+	TEXT_MESSAGE                    // Text message
+	UNK_2                           // Unknown type 2
+	JOIN_CHANNEL                    // User joined channel
+	EXIT_CHANNEL                    // User exited channel
 )
 
 type messageType int
 
+// ChatEvent represents a single message or channel membership event in a chat.
+// It includes the message text, author information, timestamp, and channel name.
 type ChatEvent struct {
 	ID   string `json:"id"`
 	Text string `json:"text"`
@@ -35,8 +38,10 @@ type ChatEvent struct {
 	Channel string
 }
 
-func (chat *Chat) OnChanneEvent(channel string, handle func(event *ChatEvent) error) (func(), error) {
-	return chat.Subscribe(compose.EventsIn(channel), func(eventType int, kwargs map[string]interface{}) error {
+// OnChannelEvent subscribes to messages in a channel. The handler is called for
+// each message or membership event. Returns an unsubscribe function.
+func (chat *Chat) OnChannelEvent(channel string, handle func(event *ChatEvent) error) (func(), error) {
+	return chat.Subscribe(compose.EventsIn(channel), func(eventType int, kwargs map[string]any) error {
 		log := chat.client.log.WithField("event_type", eventType)
 
 		if kwargs["message"] == nil {
@@ -52,6 +57,8 @@ func (chat *Chat) OnChanneEvent(channel string, handle func(event *ChatEvent) er
 	})
 }
 
+// ListMessages executes a chat RPC call and unmarshals the result as a list of messages
+// with pagination cursors (prev and next).
 func (chat *Chat) ListMessages(desc turnpike.Call) ([]*ChatEvent, int64, int64, error) {
 	output := new(struct {
 		Messages []*ChatEvent `json:"messages"`
@@ -63,6 +70,8 @@ func (chat *Chat) ListMessages(desc turnpike.Call) ([]*ChatEvent, int64, int64, 
 	return output.Messages, output.Prev, output.Next, err
 }
 
+// IterMessages returns a channel that yields messages from a channel in chronological order.
+// The iterator automatically fetches new pages as needed.
 func (chat *Chat) IterMessages(desc turnpike.Call) <-chan Result[*ChatEvent] {
 	data := make(chan Result[*ChatEvent])
 

--- a/chat.go
+++ b/chat.go
@@ -14,6 +14,8 @@ const (
 	chatRoot = "wss://chat.ifunny.co/chat"
 )
 
+// Chat establishes a WebSocket connection to the iFunny chat API using the client's
+// bearer token. Returns an error if authentication or connection fails.
 func (client *Client) Chat() (*Chat, error) {
 	log := client.log.WithField("trace_id", uuid.New().String())
 
@@ -35,13 +37,19 @@ func (client *Client) Chat() (*Chat, error) {
 	return &Chat{ws, client, hello}, nil
 }
 
+// Chat is a WebSocket connection to the iFunny chat API. It provides methods to
+// call remote procedures (Call), publish messages (Publish), and subscribe to events
+// (Subscribe). Use (*Client).Chat() to create a connection.
 type Chat struct {
 	ws     *turnpike.Client
 	client *Client
-	hello  map[string]interface{}
+	hello  map[string]any
 }
 
-func JSONDecode(data, output interface{}) error {
+// JSONDecode unmarshals a map or JSON-like structure into output, treating JSON
+// tags on the output struct's fields as field name mappings. It is a convenience
+// wrapper around mapstructure.Decode that is used throughout chat event handling.
+func JSONDecode(data, output any) error {
 	config := &mapstructure.DecoderConfig{TagName: "json", Result: output, WeaklyTypedInput: true}
 	if decode, err := mapstructure.NewDecoder(config); err != nil {
 		return err
@@ -50,7 +58,9 @@ func JSONDecode(data, output interface{}) error {
 	}
 }
 
-func (chat *Chat) Call(desc turnpike.Call, output interface{}) error {
+// Call executes a remote procedure call (RPC) and unmarshals the result into output.
+// Returns an error if the call fails or unmarshaling fails.
+func (chat *Chat) Call(desc turnpike.Call, output any) error {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
 		"type":     "CALL",
@@ -78,6 +88,7 @@ func (chat *Chat) Call(desc turnpike.Call, output interface{}) error {
 	return nil
 }
 
+// Publish publishes a message to a topic. Returns an error if the publish fails.
 func (chat *Chat) Publish(desc turnpike.Publish) error {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
@@ -95,6 +106,8 @@ func (chat *Chat) Publish(desc turnpike.Publish) error {
 	return err
 }
 
+// Subscribe subscribes to a topic and calls handle for each event. Returns an
+// unsubscribe function and an error if subscription fails.
 func (chat *Chat) Subscribe(desc turnpike.Subscribe, handle EventHandler) (func(), error) {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
@@ -104,7 +117,7 @@ func (chat *Chat) Subscribe(desc turnpike.Subscribe, handle EventHandler) (func(
 	})
 
 	log.Trace("exec subscribe")
-	err := chat.ws.Subscribe(string(desc.Topic), desc.Options, func(args []interface{}, kwargs map[string]interface{}) {
+	err := chat.ws.Subscribe(string(desc.Topic), desc.Options, func(args []any, kwargs map[string]any) {
 		eType := 0
 		if err := JSONDecode(kwargs["type"], &eType); err != nil {
 			log.Error(err)

--- a/client.go
+++ b/client.go
@@ -25,12 +25,19 @@ const (
 type Option func(*Client)
 
 // WithHTTPClient sets the underlying *http.Client used for all iFunny API
-// requests. A nil client is ignored, leaving the default in place.
+// requests. When passed multiple times the last call wins.
 func WithHTTPClient(h *http.Client) Option {
 	return func(c *Client) {
-		if h != nil {
-			c.http = h
-		}
+		c.http = h
+	}
+}
+
+// WithLogger sets the logrus.Logger used by the client. When not supplied
+// the client uses a logrus.New() logger configured with a JSON formatter at
+// LogLevel. When passed multiple times the last call wins.
+func WithLogger(log *logrus.Logger) Option {
+	return func(c *Client) {
+		c.log = log
 	}
 }
 
@@ -75,22 +82,10 @@ func MakeClientBasic(basic string, ua UserAgent, opts ...Option) (*Client, error
 	return newClient("Basic "+basic, ua, opts...), nil
 }
 
-// MakeClientLog is like MakeClient but allows the caller to provide a custom
-// logrus.Logger instance for logging. The logger is applied after MakeClient
-// completes, so the initial /account fetch still uses the default logger.
-func MakeClientLog(bearer string, ua UserAgent, log *logrus.Logger, opts ...Option) (*Client, error) {
-	client, err := MakeClient(bearer, ua, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	client.log = log
-	return client, nil
-}
-
 // Client is an authenticated iFunny API client. It holds authentication state
 // (bearer token or basic auth), user-agent information, and the authenticated user's
-// account data (Self). Use MakeClient, MakeClientBasic, or MakeClientLog to construct.
+// account data (Self). Use MakeClient or MakeClientBasic to construct; pass
+// WithLogger or WithHTTPClient to override defaults.
 type Client struct {
 	bearer, userAgent string
 	authorization     string

--- a/client.go
+++ b/client.go
@@ -34,12 +34,12 @@ func WithHTTPClient(h *http.Client) Option {
 	}
 }
 
-func newClient(authorization, userAgent string, opts ...Option) *Client {
+func newClient(authorization string, ua UserAgent, opts ...Option) *Client {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(LogLevel)
 	c := &Client{
-		userAgent:     userAgent,
+		userAgent:     ua.String(),
 		authorization: authorization,
 		http:          http.DefaultClient,
 		log:           log,
@@ -50,8 +50,11 @@ func newClient(authorization, userAgent string, opts ...Option) *Client {
 	return c
 }
 
-func MakeClient(bearer, userAgent string, opts ...Option) (*Client, error) {
-	client := newClient("bearer "+bearer, userAgent, opts...)
+// MakeClient constructs an authenticated client using a bearer token. It fetches
+// the authenticated user's account data and stores it in the returned client's
+// Self field. Returns an error if authentication fails or the account fetch fails.
+func MakeClient(bearer string, ua UserAgent, opts ...Option) (*Client, error) {
+	client := newClient("bearer "+bearer, ua, opts...)
 	client.bearer = bearer
 
 	self, err := client.GetUser(compose.UserAccount())
@@ -68,12 +71,15 @@ func MakeClient(bearer, userAgent string, opts ...Option) (*Client, error) {
 // (a basic token can't), so Self is nil. Chat requires a bearer and does not
 // work on a basic client. Call (*Client).PrimeBasic once on a freshly generated
 // token before making other requests.
-func MakeClientBasic(basic, userAgent string, opts ...Option) (*Client, error) {
-	return newClient("Basic "+basic, userAgent, opts...), nil
+func MakeClientBasic(basic string, ua UserAgent, opts ...Option) (*Client, error) {
+	return newClient("Basic "+basic, ua, opts...), nil
 }
 
-func MakeClientLog(bearer, userAgent string, log *logrus.Logger, opts ...Option) (*Client, error) {
-	client, err := MakeClient(bearer, userAgent, opts...)
+// MakeClientLog is like MakeClient but allows the caller to provide a custom
+// logrus.Logger instance for logging. The logger is applied after MakeClient
+// completes, so the initial /account fetch still uses the default logger.
+func MakeClientLog(bearer string, ua UserAgent, log *logrus.Logger, opts ...Option) (*Client, error) {
+	client, err := MakeClient(bearer, ua, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +88,9 @@ func MakeClientLog(bearer, userAgent string, log *logrus.Logger, opts ...Option)
 	return client, nil
 }
 
+// Client is an authenticated iFunny API client. It holds authentication state
+// (bearer token or basic auth), user-agent information, and the authenticated user's
+// account data (Self). Use MakeClient, MakeClientBasic, or MakeClientLog to construct.
 type Client struct {
 	bearer, userAgent string
 	authorization     string
@@ -91,12 +100,15 @@ type Client struct {
 	Self *User
 }
 
+// APIError represents an HTTP error returned by the iFunny API. It is returned
+// wrapped in an error by request methods; use AsAPIError to unwrap it.
 type APIError struct {
 	Kind        string `json:"error"`
 	Description string `json:"error_description"`
 	Status      int    `json:"status"`
 }
 
+// Error returns a human-readable error message for the API error.
 func (e APIError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s: %s", e.Status, e.Kind, e.Description)
 }
@@ -156,7 +168,10 @@ func (client *Client) header() http.Header {
 	}
 }
 
-func (client *Client) RequestJSON(desc compose.Request, output interface{}) error {
+// RequestJSON executes a composed API request and unmarshals the response body
+// into output as JSON. Returns errors from the network request or JSON decoding.
+// API errors (HTTP >= 400) are returned as *APIError wrapped in error.
+func (client *Client) RequestJSON(desc compose.Request, output any) error {
 	traceID := uuid.New().String()
 	log := client.log.WithFields(logrus.Fields{
 		"trace_id": traceID,

--- a/client.go
+++ b/client.go
@@ -19,20 +19,39 @@ const (
 	LogLevel = logrus.InfoLevel
 )
 
-func newClient(authorization, userAgent string) *Client {
+// Option configures a Client at construction time. Options are applied before
+// any network call the constructor makes (e.g. MakeClient's /account fetch),
+// so WithHTTPClient also governs the initial login request.
+type Option func(*Client)
+
+// WithHTTPClient sets the underlying *http.Client used for all iFunny API
+// requests. A nil client is ignored, leaving the default in place.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+func newClient(authorization, userAgent string, opts ...Option) *Client {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(LogLevel)
-	return &Client{
+	c := &Client{
 		userAgent:     userAgent,
 		authorization: authorization,
 		http:          http.DefaultClient,
 		log:           log,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
-func MakeClient(bearer, userAgent string) (*Client, error) {
-	client := newClient("bearer "+bearer, userAgent)
+func MakeClient(bearer, userAgent string, opts ...Option) (*Client, error) {
+	client := newClient("bearer "+bearer, userAgent, opts...)
 	client.bearer = bearer
 
 	self, err := client.GetUser(compose.UserAccount())
@@ -47,13 +66,14 @@ func MakeClient(bearer, userAgent string) (*Client, error) {
 // MakeClientBasic builds a client that authenticates with a primed basic token
 // (Authorization: Basic <basic>). Unlike MakeClient it does not fetch /account
 // (a basic token can't), so Self is nil. Chat requires a bearer and does not
-// work on a basic client.
-func MakeClientBasic(basic, userAgent string) (*Client, error) {
-	return newClient("Basic "+basic, userAgent), nil
+// work on a basic client. Call (*Client).PrimeBasic once on a freshly generated
+// token before making other requests.
+func MakeClientBasic(basic, userAgent string, opts ...Option) (*Client, error) {
+	return newClient("Basic "+basic, userAgent, opts...), nil
 }
 
-func MakeClientLog(bearer, userAgent string, log *logrus.Logger) (*Client, error) {
-	client, err := MakeClient(bearer, userAgent)
+func MakeClientLog(bearer, userAgent string, log *logrus.Logger, opts ...Option) (*Client, error) {
+	client, err := MakeClient(bearer, userAgent, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package ifunny
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,10 +19,21 @@ const (
 	LogLevel = logrus.InfoLevel
 )
 
+func newClient(authorization, userAgent string) *Client {
+	log := logrus.New()
+	log.SetFormatter(&logrus.JSONFormatter{})
+	log.SetLevel(LogLevel)
+	return &Client{
+		userAgent:     userAgent,
+		authorization: authorization,
+		http:          http.DefaultClient,
+		log:           log,
+	}
+}
+
 func MakeClient(bearer, userAgent string) (*Client, error) {
-	client := &Client{bearer, userAgent, http.DefaultClient, logrus.New(), nil}
-	client.log.SetFormatter(&logrus.JSONFormatter{})
-	client.log.SetLevel(LogLevel)
+	client := newClient("bearer "+bearer, userAgent)
+	client.bearer = bearer
 
 	self, err := client.GetUser(compose.UserAccount())
 	if err != nil {
@@ -30,6 +42,14 @@ func MakeClient(bearer, userAgent string) (*Client, error) {
 
 	client.Self = self
 	return client, nil
+}
+
+// MakeClientBasic builds a client that authenticates with a primed basic token
+// (Authorization: Basic <basic>). Unlike MakeClient it does not fetch /account
+// (a basic token can't), so Self is nil. Chat requires a bearer and does not
+// work on a basic client.
+func MakeClientBasic(basic, userAgent string) (*Client, error) {
+	return newClient("Basic "+basic, userAgent), nil
 }
 
 func MakeClientLog(bearer, userAgent string, log *logrus.Logger) (*Client, error) {
@@ -44,6 +64,7 @@ func MakeClientLog(bearer, userAgent string, log *logrus.Logger) (*Client, error
 
 type Client struct {
 	bearer, userAgent string
+	authorization     string
 	http              *http.Client
 	log               *logrus.Logger
 
@@ -58,6 +79,16 @@ type APIError struct {
 
 func (e APIError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s: %s", e.Status, e.Kind, e.Description)
+}
+
+// AsAPIError unwraps err into an *APIError. The client returns API errors
+// as *APIError, so use this rather than asserting on the value type.
+func AsAPIError(err error) (*APIError, bool) {
+	apiErr := new(APIError)
+	if errors.As(err, &apiErr) {
+		return apiErr, true
+	}
+	return nil, false
 }
 
 func request(desc compose.Request, header http.Header, client *http.Client) (*http.Response, error) {
@@ -99,7 +130,7 @@ func request(desc compose.Request, header http.Header, client *http.Client) (*ht
 
 func (client *Client) header() http.Header {
 	return http.Header{
-		"authorization":     []string{"bearer " + client.bearer},
+		"authorization":     []string{client.authorization},
 		"user-agent":        []string{client.userAgent},
 		"ifunny-project-id": []string{projectID},
 	}

--- a/comment.go
+++ b/comment.go
@@ -63,3 +63,20 @@ func (client *Client) GetCommentPage(request compose.Request) (*Page[Comment], e
 func (client *Client) IterComments(id string) <-chan Result[*Comment] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Comments(id, limit, page) }, client.GetCommentPage)
 }
+
+func (client *Client) GetRepliesPage(request compose.Request) (*Page[Comment], error) {
+	content := new(struct {
+		Data struct {
+			Replies Page[Comment] `json:"replies"`
+		} `json:"data"`
+	})
+
+	err := client.RequestJSON(request, content)
+	return &content.Data.Replies, err
+}
+
+func (client *Client) IterReplies(cid, id string) <-chan Result[*Comment] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+		return compose.Replies(cid, id, limit, page)
+	}, client.GetRepliesPage)
+}

--- a/comment.go
+++ b/comment.go
@@ -4,6 +4,9 @@ import (
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
+// Comment represents a user's comment on content. It includes the comment text,
+// author information, engagement metrics (smiles/unsmiles), and threading metadata
+// (parent, depth, etc.).
 type Comment struct {
 	ID           string `json:"id"`
 	CID          string `json:"cid"`
@@ -49,6 +52,8 @@ type Comment struct {
 	} `json:"content_thumbs"`
 }
 
+// GetCommentPage fetches a single page of comments given a composed request.
+// It is used internally by comment iteration methods and exported for advanced use cases.
 func (client *Client) GetCommentPage(request compose.Request) (*Page[Comment], error) {
 	content := new(struct {
 		Data struct {
@@ -60,10 +65,14 @@ func (client *Client) GetCommentPage(request compose.Request) (*Page[Comment], e
 	return &content.Data.Comments, err
 }
 
+// IterComments returns a channel that yields top-level comments on content (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterComments(id string) <-chan Result[*Comment] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Comments(id, limit, page) }, client.GetCommentPage)
 }
 
+// GetRepliesPage fetches a single page of replies to a comment given a composed request.
+// It is used internally by reply iteration methods and exported for advanced use cases.
 func (client *Client) GetRepliesPage(request compose.Request) (*Page[Comment], error) {
 	content := new(struct {
 		Data struct {
@@ -75,6 +84,8 @@ func (client *Client) GetRepliesPage(request compose.Request) (*Page[Comment], e
 	return &content.Data.Replies, err
 }
 
+// IterReplies returns a channel that yields replies to a specific comment (identified by cid on content id).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterReplies(cid, id string) <-chan Result[*Comment] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Replies(cid, id, limit, page)

--- a/compose/channel.go
+++ b/compose/channel.go
@@ -32,21 +32,24 @@ const (
 	RoleNormie ChannelRole = 2 // ???
 )
 
+// JoinedChannels subscribes to updates for a user's joined channels.
 func JoinedChannels(id string) turnpike.Subscribe {
 	return turnpike.Subscribe{Topic: URI("user." + id + ".chats")}
 }
 
+// HideChannel composes a call to hide a channel from the user's view.
 func HideChannel(channel string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("hide_chat"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
+// CreateChannel composes a call to create a new channel with the specified type and members.
 func CreateChannel(kind ChannelType, id, title, description, coverURL string, invitedIDs []string) turnpike.Call {
 	call := turnpike.Call{
 		Procedure: URI("create_channel"),
-		ArgumentsKw: map[string]interface{}{
+		ArgumentsKw: map[string]any{
 			"type":             kind,
 			"id":               id,
 			"title":            title,
@@ -59,6 +62,7 @@ func CreateChannel(kind ChannelType, id, title, description, coverURL string, in
 	return call
 }
 
+// DMChannelName generates a canonical DM channel name from participant user IDs.
 func DMChannelName(self string, them []string) string {
 	us := append(them, self)
 	sort.Strings(us)
@@ -71,10 +75,11 @@ func DMChannelName(self string, them []string) string {
 	return strings.Join(backwards, "_")
 }
 
+// GetDMChannel composes a call to get or create a direct message channel with specified users.
 func GetDMChannel(id string, them ...string) turnpike.Call {
 	return turnpike.Call{
 		Procedure: URI("get_or_create_chat"),
-		ArgumentsKw: map[string]interface{}{
+		ArgumentsKw: map[string]any{
 			"type":  ChannelDM,
 			"users": them,
 			"name":  DMChannelName(id, them),
@@ -82,6 +87,7 @@ func GetDMChannel(id string, them ...string) turnpike.Call {
 	}
 }
 
+// NewChannel composes a call to create a new chat channel with the specified type and members.
 func NewChannel(title, name, description string, invite []string, channelType ChannelType) turnpike.Call {
 	if description != "" && channelType == ChannelPrivate {
 		panic("cannot add a description to a private channel")
@@ -89,7 +95,7 @@ func NewChannel(title, name, description string, invite []string, channelType Ch
 
 	return turnpike.Call{
 		Procedure: URI("new_chat"),
-		ArgumentsKw: map[string]interface{}{
+		ArgumentsKw: map[string]any{
 			"users":       invite,
 			"title":       title,
 			"name":        name,
@@ -99,24 +105,27 @@ func NewChannel(title, name, description string, invite []string, channelType Ch
 	}
 }
 
+// GetChannel composes a call to get channel details by name.
 func GetChannel(channel string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("get_chat"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
+// JoinChannel composes a call to join a channel by name.
 func JoinChannel(channel string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("join_chat"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
+// ExitChannel composes a call to leave a channel by name.
 func ExitChannel(channel string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("leave_chat"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
@@ -124,6 +133,7 @@ var (
 	ChatsTrending = Request{Method: "GET", Path: "/chats/trending"}
 )
 
+// ChatsQuery composes a request to search for open channels by query string with pagination.
 func ChatsQuery(query string, limit int, page Page[string]) Request {
 	return Request{
 		Method: "GET", Path: "/chats/open_channels",

--- a/compose/comment.go
+++ b/compose/comment.go
@@ -1,19 +1,11 @@
 package compose
 
-import (
-	"fmt"
-	"net/url"
-)
-
+// Comments composes a request for comments on a content item with pagination.
 func Comments(id string, limit int, page Page[string]) Request {
-	q := url.Values{"limit": []string{fmt.Sprint(limit)}}
-	if page.Key != NONE {
-		q.Set(string(page.Key), page.Value)
-	}
-
-	return get("/content/"+id+"/comments", q)
+	return get("/content/"+id+"/comments", feedParams(limit, page))
 }
 
+// Replies composes a request for replies to a comment with pagination.
 func Replies(cid, id string, limit int, page Page[string]) Request {
 	return get("/content/"+cid+"/comments/"+id+"/replies", feedParams(limit, page))
 }

--- a/compose/comment.go
+++ b/compose/comment.go
@@ -13,3 +13,7 @@ func Comments(id string, limit int, page Page[string]) Request {
 
 	return get("/content/"+id+"/comments", q)
 }
+
+func Replies(cid, id string, limit int, page Page[string]) Request {
+	return get("/content/"+cid+"/comments/"+id+"/replies", feedParams(limit, page))
+}

--- a/compose/content.go
+++ b/compose/content.go
@@ -29,6 +29,18 @@ func Timeline(id string, limit int, page Page[string]) Request {
 	return get("/timelines/users/"+id, feedParams(limit, page))
 }
 
+func TimelineByNick(nick string, limit int, page Page[string]) Request {
+	return get("/timelines/users/by_nick/"+nick, feedParams(limit, page))
+}
+
+func Smiles(id string, limit int, page Page[string]) Request {
+	return get("/content/"+id+"/smiles", feedParams(limit, page))
+}
+
+func Republished(id string, limit int, page Page[string]) Request {
+	return get("/content/"+id+"/republished", feedParams(limit, page))
+}
+
 /*
 content_top_today
 content_top_this_week

--- a/compose/content.go
+++ b/compose/content.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 )
 
+// ContentByID composes a request for content by ID.
 func ContentByID(id string) Request {
 	return get("/content/"+id, nil)
 }
@@ -17,6 +18,7 @@ func feedParams(limit int, page Page[string]) url.Values {
 	return q
 }
 
+// Feed composes a request for a named content feed (e.g. "featured", "trending") with pagination.
 func Feed(feed string, limit int, page Page[string]) Request {
 	if feed == "collective" {
 		return Request{"POST", "/feeds/collective", nil, feedParams(limit, page)}
@@ -25,18 +27,22 @@ func Feed(feed string, limit int, page Page[string]) Request {
 	return get("/feeds/"+feed, feedParams(limit, page))
 }
 
+// Timeline composes a request for a user's content timeline by ID with pagination.
 func Timeline(id string, limit int, page Page[string]) Request {
 	return get("/timelines/users/"+id, feedParams(limit, page))
 }
 
+// TimelineByNick composes a request for a user's content timeline by nick with pagination.
 func TimelineByNick(nick string, limit int, page Page[string]) Request {
 	return get("/timelines/users/by_nick/"+nick, feedParams(limit, page))
 }
 
+// Smiles composes a request for users who smiled on a content item with pagination.
 func Smiles(id string, limit int, page Page[string]) Request {
 	return get("/content/"+id+"/smiles", feedParams(limit, page))
 }
 
+// Republished composes a request for users who republished a content item with pagination.
 func Republished(id string, limit int, page Page[string]) Request {
 	return get("/content/"+id+"/republished", feedParams(limit, page))
 }
@@ -82,6 +88,7 @@ chats_popular_last_week
 chats_new_chats
 chats_top_by_members
 */
+// Explore composes a request for content from an explore compilation by ID with pagination.
 func Explore(id string, limit int, page Page[string]) Request {
 	return Request{"POST", "/explore/compilation/" + id, nil, feedParams(limit, page)}
 }

--- a/compose/invite.go
+++ b/compose/invite.go
@@ -2,35 +2,35 @@ package compose
 
 import "github.com/gastrodon/turnpike"
 
-func inviteCall(accept bool) string {
-	if accept {
-		return "invite.accept"
-	}
-
-	return "invite.decline"
-}
-
+// Invite composes a call to invite users to a channel.
 func Invite(channel string, users []string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("invite.invite"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel, "users": users},
+		ArgumentsKw: map[string]any{"chat_name": channel, "users": users},
 	}
 }
 
+// InviteResponse composes a call to accept or decline a channel invitation.
 func InviteResponse(channel string, accept bool) turnpike.Call {
+	proc := "invite.decline"
+	if accept {
+		proc = "invite.accept"
+	}
 	return turnpike.Call{
-		Procedure:   URI(inviteCall(accept)),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		Procedure:   URI(proc),
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
+// ReceiveInvite subscribes to channel invitations for a user.
 func ReceiveInvite(id string) turnpike.Subscribe {
 	return turnpike.Subscribe{Topic: URI("user." + id + ".invites")}
 }
 
+// Kick composes a call to remove a user from a channel.
 func Kick(channel, user string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("kick_member"),
-		ArgumentsKw: map[string]interface{}{"user_id": user, "chat_name": channel},
+		ArgumentsKw: map[string]any{"user_id": user, "chat_name": channel},
 	}
 }

--- a/compose/message.go
+++ b/compose/message.go
@@ -4,15 +4,13 @@ import (
 	"github.com/gastrodon/turnpike"
 )
 
-/*
-publish a text message to a channel
-*/
+// MessageTo publishes a text message to a channel.
 func MessageTo(channel, text string) turnpike.Publish {
 	return turnpike.Publish{
 		Topic:     URI("chat." + channel),
-		Options:   map[string]interface{}{"acknowledge": 1, "exclude_me": 1},
+		Options:   map[string]any{"acknowledge": 1, "exclude_me": 1},
 		Arguments: nil,
-		ArgumentsKw: map[string]interface{}{
+		ArgumentsKw: map[string]any{
 			"message_type": 1,
 			"type":         200,
 			"text":         text,
@@ -20,9 +18,7 @@ func MessageTo(channel, text string) turnpike.Publish {
 	}
 }
 
-/*
-subscribe to events happening in a channel
-*/
+// EventsIn subscribes to events and messages in a channel.
 func EventsIn(channel string) turnpike.Subscribe {
 	return turnpike.Subscribe{
 		Topic:   URI("chat." + channel),
@@ -30,10 +26,11 @@ func EventsIn(channel string) turnpike.Subscribe {
 	}
 }
 
+// ListMessages composes a call to list messages in a channel with pagination.
 func ListMessages(channel string, limit int, page Page[int]) turnpike.Call {
 	call := turnpike.Call{
 		Procedure: URI("list_messages"),
-		ArgumentsKw: map[string]interface{}{
+		ArgumentsKw: map[string]any{
 			"chat_name": channel,
 			"limit":     limit,
 		},

--- a/compose/user.go
+++ b/compose/user.go
@@ -37,3 +37,11 @@ func UserByNick(nick string) Request {
 func UserAccount() Request {
 	return get("/account", nil)
 }
+
+func Subscribers(id string, limit int, page Page[string]) Request {
+	return get("/users/"+id+"/subscribers", feedParams(limit, page))
+}
+
+func Subscriptions(id string, limit int, page Page[string]) Request {
+	return get("/users/"+id+"/subscriptions", feedParams(limit, page))
+}

--- a/compose/user.go
+++ b/compose/user.go
@@ -2,46 +2,51 @@ package compose
 
 import "github.com/gastrodon/turnpike"
 
-/*
-call out to get chat contacts
-*/
+// Contacts composes a call to list chat contacts.
 func Contacts(limit int) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("list_contacts"),
-		ArgumentsKw: map[string]interface{}{"limit": limit},
+		ArgumentsKw: map[string]any{"limit": limit},
 	}
 }
 
+// SearchContacts composes a call to search chat contacts by query.
 func SearchContacts(query string, limit int) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("search_contacts"),
-		ArgumentsKw: map[string]interface{}{"query": query, "limit": limit},
+		ArgumentsKw: map[string]any{"query": query, "limit": limit},
 	}
 }
 
+// Operators composes a call to list operators in a channel.
 func Operators(channel string) turnpike.Call {
 	return turnpike.Call{
 		Procedure:   URI("list_operators"),
-		ArgumentsKw: map[string]interface{}{"chat_name": channel},
+		ArgumentsKw: map[string]any{"chat_name": channel},
 	}
 }
 
+// UserByID composes a request for user details by ID.
 func UserByID(id string) Request {
 	return get("/users/"+id, nil)
 }
 
+// UserByNick composes a request for user details by nick.
 func UserByNick(nick string) Request {
 	return get("/users/by_nick/"+nick, nil)
 }
 
+// UserAccount composes a request for the authenticated user's account details.
 func UserAccount() Request {
 	return get("/account", nil)
 }
 
+// Subscribers composes a request for a user's subscribers with pagination.
 func Subscribers(id string, limit int, page Page[string]) Request {
 	return get("/users/"+id+"/subscribers", feedParams(limit, page))
 }
 
+// Subscriptions composes a request for a user's subscriptions with pagination.
 func Subscriptions(id string, limit int, page Page[string]) Request {
 	return get("/users/"+id+"/subscriptions", feedParams(limit, page))
 }

--- a/content.go
+++ b/content.go
@@ -6,12 +6,15 @@ import (
 
 // TODO types of content, missing a bunch of content types
 // an enum type when we have all of them ( will we ever? )
+// Content types returned by the API.
 const (
-	CONTENT_PIC        = "pic"
-	CONTENT_VIDEO_CLIP = "video_clip"
-	CONTENT_COMICS     = "comics" // created from the in-app comic maker
+	CONTENT_PIC        = "pic"        // Picture/image content
+	CONTENT_VIDEO_CLIP = "video_clip" // Video content
+	CONTENT_COMICS     = "comics"     // created from the in-app comic maker
 )
 
+// Content represents a post (image, video, or comic) on iFunny. It includes metadata
+// like creation date, stats (smiles, comments), and the creator's information.
 type Content struct {
 	Type        string   `json:"type"`
 	ID          string   `json:"id"`
@@ -64,6 +67,9 @@ type Content struct {
 	} `json:"video_clip,omitempty"`
 }
 
+// Cursor holds pagination metadata for paginated API responses. It includes opaque
+// cursor strings for the next and previous pages, and flags indicating whether those
+// pages exist.
 type Cursor struct {
 	Cursors struct {
 		Next string `json:"next,omitempty"`
@@ -73,6 +79,7 @@ type Cursor struct {
 	HasPrev bool `json:"hasPrev"`
 }
 
+// GetContent fetches a single piece of content by ID.
 func (client *Client) GetContent(id string) (*Content, error) {
 	content := new(struct {
 		Data Content `json:"data"`
@@ -81,6 +88,8 @@ func (client *Client) GetContent(id string) (*Content, error) {
 	return &content.Data, err
 }
 
+// GetFeedPage fetches a single page of content given a composed request. It is used
+// internally by feed iteration methods and is exported for advanced use cases.
 func (client *Client) GetFeedPage(request compose.Request) (*Page[Content], error) {
 	content := new(struct {
 		Data struct {
@@ -92,28 +101,34 @@ func (client *Client) GetFeedPage(request compose.Request) (*Page[Content], erro
 	return &content.Data.Content, err
 }
 
-// func (client *Client) IterFeed(feed string) Iterator[*Content] {
-
-// }
-
+// IterFeed returns a channel that yields content from a named feed (e.g. "hot", "trending").
+// The iterator automatically fetches new pages as needed. Close the channel to stop iteration.
 func (client *Client) IterFeed(feed string) <-chan Result[*Content] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Feed(feed, limit, page) }, client.GetFeedPage)
 }
 
+// IterTimeline returns a channel that yields content posted by a user (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterTimeline(id string) <-chan Result[*Content] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Timeline(id, limit, page) }, client.GetFeedPage)
 }
 
+// IterTimelineByNick returns a channel that yields content posted by a user (identified by nick/username).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterTimelineByNick(nick string) <-chan Result[*Content] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.TimelineByNick(nick, limit, page)
 	}, client.GetFeedPage)
 }
 
+// IterSmiles returns a channel that yields users who smiled at the content (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterSmiles(id string) <-chan Result[*User] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Smiles(id, limit, page) }, client.GetUsersPage)
 }
 
+// IterRepublishers returns a channel that yields users who republished the content (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterRepublishers(id string) <-chan Result[*User] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Republished(id, limit, page)

--- a/content.go
+++ b/content.go
@@ -103,3 +103,19 @@ func (client *Client) IterFeed(feed string) <-chan Result[*Content] {
 func (client *Client) IterTimeline(id string) <-chan Result[*Content] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Timeline(id, limit, page) }, client.GetFeedPage)
 }
+
+func (client *Client) IterTimelineByNick(nick string) <-chan Result[*Content] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+		return compose.TimelineByNick(nick, limit, page)
+	}, client.GetFeedPage)
+}
+
+func (client *Client) IterSmiles(id string) <-chan Result[*User] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Smiles(id, limit, page) }, client.GetUsersPage)
+}
+
+func (client *Client) IterRepublishers(id string) <-chan Result[*User] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+		return compose.Republished(id, limit, page)
+	}, client.GetUsersPage)
+}

--- a/event.go
+++ b/event.go
@@ -1,11 +1,14 @@
 package ifunny
 
-type EventHandler func(eventType int, kwargs map[string]interface{}) error
+// EventHandler is a callback for chat events. It receives an event type code and the
+// raw event data as a map. Returns an error if event handling fails.
+type EventHandler func(eventType int, kwargs map[string]any) error
 
+// Chat event type constants.
 const (
-	EVENT_UNKNOWN = -1
-	EVENT_JOIN    = 100
-	EVENT_EXIT    = 101
-	EVENT_MESSAGE = 200
-	EVENT_INVITED = 300
+	EVENT_UNKNOWN = -1  // Unknown event type
+	EVENT_JOIN    = 100 // User joined a channel
+	EVENT_EXIT    = 101 // User exited a channel
+	EVENT_MESSAGE = 200 // New message in channel
+	EVENT_INVITED = 300 // User was invited to a channel
 )

--- a/examples/chat-iter/main.go
+++ b/examples/chat-iter/main.go
@@ -17,7 +17,7 @@ func printChannel(c *ifunny.ChatChannel) {
 
 func main() {
 	q := "hello"
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 
 	fmt.Printf("iterating results for q=%s\n", q)
 	iter := client.IterChannelsQuery(q)

--- a/examples/chat-messages/main.go
+++ b/examples/chat-messages/main.go
@@ -12,7 +12,7 @@ var bearer = os.Getenv("IFUNNY_BEARER")
 var userAgent = os.Getenv("IFUNNY_USER_AGENT")
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 	chat, _ := client.Chat()
 
 	channels, err := client.GetChannels(compose.ChatsTrending)

--- a/examples/comment/main.go
+++ b/examples/comment/main.go
@@ -17,7 +17,7 @@ func printComment(c *ifunny.Comment) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 	comments, err := client.GetCommentPage(compose.Comments("r4mB8i4NA", 30, compose.NoPage[string]()))
 	if err != nil {
 		panic(err)

--- a/examples/content-iter/main.go
+++ b/examples/content-iter/main.go
@@ -16,7 +16,7 @@ func printContent(c *ifunny.Content) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 
 	fmt.Println("iterating features")
 	iter := client.IterFeed("featured")

--- a/examples/content/main.go
+++ b/examples/content/main.go
@@ -17,7 +17,7 @@ func printContent(c *ifunny.Content) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 	content, err := client.GetContent("lgzM46Im9")
 	if err != nil {
 		panic(err)

--- a/examples/explore/main.go
+++ b/examples/explore/main.go
@@ -21,7 +21,7 @@ func printUser(u *ifunny.User) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 
 	page, err := client.ExploreContentPage(compose.Explore("content_shuffle", 30, compose.NoPage[string]()))
 	if err != nil {

--- a/examples/user/main.go
+++ b/examples/user/main.go
@@ -12,7 +12,7 @@ var bearer = os.Getenv("IFUNNY_BEARER")
 var userAgent = os.Getenv("IFUNNY_USER_AGENT")
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, userAgent)
+	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
 	u, err := client.GetUser(compose.UserByNick("gastrodon"))
 	if err != nil {
 		panic(err)

--- a/explore.go
+++ b/explore.go
@@ -15,14 +15,20 @@ func explorePage[T Content | User | ChatChannel](client *Client, request compose
 	return &content.Data.Value.Context, err
 }
 
+// ExploreContentPage fetches a single page of explore content given a composed request.
+// It is used internally by explore iteration methods and exported for advanced use cases.
 func (client *Client) ExploreContentPage(requet compose.Request) (*Page[Content], error) {
 	return explorePage[Content](client, requet)
 }
 
+// ExploreUserPage fetches a single page of explore users given a composed request.
+// It is used internally by explore iteration methods and exported for advanced use cases.
 func (client *Client) ExploreUserPage(requet compose.Request) (*Page[User], error) {
 	return explorePage[User](client, requet)
 }
 
+// ExploreChatChannelPage fetches a single page of explore chat channels given a composed request.
+// It is used internally by explore iteration methods and exported for advanced use cases.
 func (client *Client) ExploreChatChannelPage(requet compose.Request) (*Page[ChatChannel], error) {
 	return explorePage[ChatChannel](client, requet)
 }
@@ -37,14 +43,20 @@ func iterExplore[T Content | User | ChatChannel](client *Client, compilation str
 	)
 }
 
+// IterExploreContent returns a channel that yields content from an explore compilation.
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreContent(compilation string) <-chan Result[*Content] {
 	return iterExplore[Content](client, compilation)
 }
 
+// IterExploreUser returns a channel that yields users from an explore compilation.
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreUser(compilation string) <-chan Result[*User] {
 	return iterExplore[User](client, compilation)
 }
 
+// IterExploreChatChannel returns a channel that yields chat channels from an explore compilation.
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreChatChannel(compilation string) <-chan Result[*ChatChannel] {
 	return iterExplore[ChatChannel](client, compilation)
 }

--- a/iter.go
+++ b/iter.go
@@ -41,8 +41,8 @@ func iterFrom[T Content | Comment | User | ChatChannel](client *Client, composer
 				return
 			}
 
-			for _, v := range items.Items {
-				data <- Result[*T]{V: &v}
+			for i := range items.Items {
+				data <- Result[*T]{V: &items.Items[i]}
 			}
 
 			log.Tracef("next: %s, has next: %t",

--- a/iter.go
+++ b/iter.go
@@ -6,16 +6,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Page represents a paginated response from the iFunny API. It contains a slice
+// of items of type T and pagination metadata (Cursor).
 type Page[T Comment | Content | User | ChatChannel] struct {
 	Items  []T    `json:"items"`
 	Paging Cursor `json:"paging"`
 }
 
+// Result carries one item from an iterator or an error. Iterators close their
+// channel when done; a mid-iteration failure is delivered as a final Result
+// with Err set (and V zero-valued) before the channel closes.
 type Result[T any] struct {
 	V   T
 	Err error
 }
 
+// Iterator is a convenience wrapper around a channel of Results. It holds functions
+// to obtain the result channel (Iter) and to stop iteration early (Stop). Not
+// currently used by the root package; it is available for future use or custom iterators.
 type Iterator[T any] struct {
 	Iter func() <-chan Result[T]
 	Stop func()

--- a/user.go
+++ b/user.go
@@ -5,6 +5,9 @@ import (
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
+// User represents an iFunny user account. It includes profile information (nick, about, email),
+// verification and status flags (verified, banned, etc.), and engagement statistics
+// (subscribers, subscriptions, posts, etc.).
 type User struct {
 	Email            string `json:"email"`
 	SafeMode         bool   `json:"safe_mode"`
@@ -36,6 +39,7 @@ type User struct {
 	} `json:"num"`
 }
 
+// GetUser fetches a single user given a composed request (e.g. compose.UserAccount() for the authenticated user).
 func (client *Client) GetUser(desc compose.Request) (*User, error) {
 	user := new(struct {
 		Data User `json:"data"`
@@ -45,10 +49,11 @@ func (client *Client) GetUser(desc compose.Request) (*User, error) {
 	return &user.Data, err
 }
 
-// GetUsersPage fetches a page of any endpoint whose envelope is
-// data.users: content smiles, content republishers, user subscribers, and
-// user subscriptions. These endpoints return a reduced projection of User
-// (no email/privacy fields); absent fields are simply zero-valued.
+// GetUsersPage fetches a page of users from endpoints whose envelope is data.users
+// (e.g., content smiles, content republishers, user subscribers, subscriptions).
+// It is used internally by user iteration methods and exported for advanced use cases.
+// These endpoints return a reduced projection of User (no email/privacy fields);
+// absent fields are simply zero-valued.
 func (client *Client) GetUsersPage(request compose.Request) (*Page[User], error) {
 	users := new(struct {
 		Data struct {
@@ -60,18 +65,23 @@ func (client *Client) GetUsersPage(request compose.Request) (*Page[User], error)
 	return &users.Data.Users, err
 }
 
+// IterSubscribers returns a channel that yields users who follow the user (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterSubscribers(id string) <-chan Result[*User] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Subscribers(id, limit, page)
 	}, client.GetUsersPage)
 }
 
+// IterSubscriptions returns a channel that yields users followed by the user (identified by ID).
+// The iterator automatically fetches new pages as needed.
 func (client *Client) IterSubscriptions(id string) <-chan Result[*User] {
 	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Subscriptions(id, limit, page)
 	}, client.GetUsersPage)
 }
 
+// GetUsers executes a chat RPC call and unmarshals the result as a list of users.
 func (chat *Chat) GetUsers(desc turnpike.Call) ([]*User, error) {
 	output := new(struct {
 		Users []*User `json:"users"`

--- a/user.go
+++ b/user.go
@@ -45,6 +45,33 @@ func (client *Client) GetUser(desc compose.Request) (*User, error) {
 	return &user.Data, err
 }
 
+// GetUsersPage fetches a page of any endpoint whose envelope is
+// data.users: content smiles, content republishers, user subscribers, and
+// user subscriptions. These endpoints return a reduced projection of User
+// (no email/privacy fields); absent fields are simply zero-valued.
+func (client *Client) GetUsersPage(request compose.Request) (*Page[User], error) {
+	users := new(struct {
+		Data struct {
+			Users Page[User] `json:"users"`
+		} `json:"data"`
+	})
+
+	err := client.RequestJSON(request, users)
+	return &users.Data.Users, err
+}
+
+func (client *Client) IterSubscribers(id string) <-chan Result[*User] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+		return compose.Subscribers(id, limit, page)
+	}, client.GetUsersPage)
+}
+
+func (client *Client) IterSubscriptions(id string) <-chan Result[*User] {
+	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+		return compose.Subscriptions(id, limit, page)
+	}, client.GetUsersPage)
+}
+
 func (chat *Chat) GetUsers(desc turnpike.Call) ([]*User, error) {
 	output := new(struct {
 		Users []*User `json:"users"`


### PR DESCRIPTION
## Summary

This PR implements three independent changes to the iFunny Go client:

### Change A: Discovery Iterators & AsAPIError

Adds cursor-paginated iterators for:
- Comment replies (`IterReplies`)
- Content smilers (`IterSmiles`)
- Content republishers (`IterRepublishers`)
- User subscribers (`IterSubscribers`)
- User subscriptions (`IterSubscriptions`)
- Timeline by nick (`IterTimelineByNick`)

Also adds `AsAPIError(err)` helper to unwrap API errors using `errors.As` rather than value type assertion (the client returns `*APIError`).

### Change B: Range Variable Fix

Fixes address-of loop variable issue in `iterFrom` by using index-based slice access (`&items.Items[i]`) instead of address-of range variable (`&v`). Ensures correctness independent of Go version and channel timing.

### Change C: Basic-Token Authentication

Implements anonymous, read-only auth via iFunny basic tokens (`Authorization: Basic <token>`):
- `GenerateBasic()` - Creates fresh unprimed basic tokens using iFunny's client-side algorithm
- `PrimeBasic(basic, userAgent)` - Activates a token with GET /counters and ~15s server-side wait
- `MakeClientBasic(basic, userAgent)` - Creates a basic-authenticated client

**Note:** Basic clients are REST-only (chat requires bearer token) and have `Self` set to nil (basic tokens can't access /account).

### Verification

- ✓ gofmt -l . (no formatting issues)
- ✓ go build ./...
- ✓ go vet ./...
- ✓ go test ./...