### PR TITLE
Thread context.Context through all HTTP-backed accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Anonymous, read-only client via a minted basic token:
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-ifunny/ifunny-go"
@@ -23,15 +24,16 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	basic, _ := ifunny.GenerateBasic()
 	ua := ifunny.Android{Version: "14"}.UserAgent()
 
 	client, _ := ifunny.MakeClientBasic(basic, ua)
-	if err := client.PrimeBasic(); err != nil { // ~15s server-side wait
+	if err := client.PrimeBasic(ctx); err != nil { // ~15s server-side wait
 		panic(err)
 	}
 
-	u, err := client.GetUser(compose.UserByNick("woof"))
+	u, err := client.GetUser(ctx, compose.UserByNick("woof"))
 	if err != nil {
 		panic(err)
 	}
@@ -39,7 +41,7 @@ func main() {
 }
 ```
 
-For an authenticated client (chat, personalized feeds, `Self`), pass a bearer token to `ifunny.MakeClient` instead. Iterators over feeds, comments, users, and chat channels live as `Iter*` methods on `*Client` and `*Chat`. See [`examples/`](examples/) for more.
+For an authenticated client (chat, personalized feeds, `Self`), pass a bearer token to `ifunny.MakeClient` instead. Every HTTP-backed accessor takes a `context.Context` as its first argument, so requests honor cancellation and deadlines; cancelling the ctx also stops an in-flight `Iter*` pager. Iterators over feeds, comments, users, and chat channels live as `Iter*` methods on `*Client` and `*Chat`. See [`examples/`](examples/) for more.
 
 ## TODO
 - [x] Move over the chat library code from [discovery-bot](https://github.com/open-ifunny/discovery-bot)

--- a/basic.go
+++ b/basic.go
@@ -1,6 +1,7 @@
 package ifunny
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"
@@ -125,9 +126,11 @@ func GenerateBasic() (string, error) {
 // PrimeBasic activates the basic token this client was constructed with: one
 // GET /counters, then the server-side ~15s wait. Call once on a freshly
 // generated token before making other requests. Uses the client's configured
-// *http.Client, so any custom transport/timeouts are honored.
-func (client *Client) PrimeBasic() error {
-	req, err := http.NewRequest("GET", client.apiRoot+"/counters", nil)
+// *http.Client, so any custom transport/timeouts are honored. The ctx governs
+// both the /counters request and the subsequent wait, so a cancelled ctx aborts
+// priming promptly and returns ctx.Err().
+func (client *Client) PrimeBasic(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", client.apiRoot+"/counters", nil)
 	if err != nil {
 		return err
 	}
@@ -143,6 +146,10 @@ func (client *Client) PrimeBasic() error {
 		return fmt.Errorf("prime basic token: HTTP %d", resp.StatusCode)
 	}
 
-	time.Sleep(15 * time.Second)
-	return nil
+	select {
+	case <-time.After(15 * time.Second):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/basic_integration_test.go
+++ b/basic_integration_test.go
@@ -3,6 +3,7 @@
 package ifunny
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -58,12 +59,13 @@ func TestBasicFlow(t *testing.T) {
 				t.Fatalf("MakeClientBasic: %v", err)
 			}
 
+			ctx := context.Background()
 			t.Log("priming (this takes ~15s)")
-			if err := client.PrimeBasic(); err != nil {
+			if err := client.PrimeBasic(ctx); err != nil {
 				t.Fatalf("PrimeBasic: %v", err)
 			}
 
-			user, err := client.GetUser(compose.UserByNick(nick))
+			user, err := client.GetUser(ctx, compose.UserByNick(nick))
 			if err != nil {
 				t.Fatalf("GetUser(by_nick %s): %v", nick, err)
 			}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,6 +1,8 @@
 package bot
 
 import (
+	"context"
+
 	"github.com/google/uuid"
 	"github.com/open-ifunny/ifunny-go"
 	"github.com/open-ifunny/ifunny-go/compose"
@@ -17,16 +19,21 @@ type Bot struct {
 	Chat   *ifunny.Chat
 	Log    *logrus.Logger
 
+	ctx          context.Context
 	recvEvents   chan Context
 	unsubEvents  map[string]func()
 	handleEvents map[string]filtHandler
 }
 
-func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
+// MakeBot constructs a bot and authenticates its client. The ctx governs the
+// initial /account fetch and is retained as the bot's base context for the
+// per-event API calls made by a Context (e.g. Caller's user lookup), so
+// cancelling it aborts in-flight lookups.
+func MakeBot(ctx context.Context, bearer string, ua ifunny.UserAgent) (*Bot, error) {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(ifunny.LogLevel)
-	client, err := ifunny.MakeClient(bearer, ua, ifunny.WithLogger(log))
+	client, err := ifunny.MakeClient(ctx, bearer, ua, ifunny.WithLogger(log))
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +47,7 @@ func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
 		Client:       client,
 		Chat:         chat,
 		Log:          log,
+		ctx:          ctx,
 		recvEvents:   make(chan Context),
 		unsubEvents:  make(map[string]func()),
 		handleEvents: make(map[string]filtHandler, 0),

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -36,7 +36,7 @@ func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
 		return nil, err
 	}
 
-	chat, err := client.Chat()
+	chat, err := client.Chat(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (bot *Bot) Subscribe(channel string) {
 		unsub()
 	}
 
-	bot.Chat.Subscribe(compose.EventsIn(channel), func(eventType int, eventKW map[string]any) error {
+	bot.Chat.Subscribe(context.Background(), compose.EventsIn(channel), func(eventType int, eventKW map[string]any) error {
 		log = log.WithFields(logrus.Fields{"event_type": eventType, "channel": channel})
 		log.Trace("handle event")
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -19,21 +19,19 @@ type Bot struct {
 	Chat   *ifunny.Chat
 	Log    *logrus.Logger
 
-	ctx          context.Context
 	recvEvents   chan Context
 	unsubEvents  map[string]func()
 	handleEvents map[string]filtHandler
 }
 
-// MakeBot constructs a bot and authenticates its client. The ctx governs the
-// initial /account fetch and is retained as the bot's base context for the
-// per-event API calls made by a Context (e.g. Caller's user lookup), so
-// cancelling it aborts in-flight lookups.
-func MakeBot(ctx context.Context, bearer string, ua ifunny.UserAgent) (*Bot, error) {
+// MakeBot constructs a bot and authenticates its client. The bot's internal
+// API calls use context.Background(); it does not currently support
+// cancellation of its construction-time or per-event lookups.
+func MakeBot(bearer string, ua ifunny.UserAgent) (*Bot, error) {
 	log := logrus.New()
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetLevel(ifunny.LogLevel)
-	client, err := ifunny.MakeClient(ctx, bearer, ua, ifunny.WithLogger(log))
+	client, err := ifunny.MakeClient(context.Background(), bearer, ua, ifunny.WithLogger(log))
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +45,6 @@ func MakeBot(ctx context.Context, bearer string, ua ifunny.UserAgent) (*Bot, err
 		Client:       client,
 		Chat:         chat,
 		Log:          log,
-		ctx:          ctx,
 		recvEvents:   make(chan Context),
 		unsubEvents:  make(map[string]func()),
 		handleEvents: make(map[string]filtHandler, 0),

--- a/bot/context.go
+++ b/bot/context.go
@@ -57,7 +57,7 @@ func (ctx *eventContext) Channel() (*ifunny.ChatChannel, error) {
 		return ctx.channel, nil
 	}
 
-	channel, err := ctx.robot.Chat.GetChannel(compose.GetChannel(ctx.channelName))
+	channel, err := ctx.robot.Chat.GetChannel(context.Background(), compose.GetChannel(ctx.channelName))
 	if err == nil {
 		ctx.channel = channel
 	}
@@ -66,7 +66,7 @@ func (ctx *eventContext) Channel() (*ifunny.ChatChannel, error) {
 }
 
 func (ctx *eventContext) Send(message string) error {
-	return ctx.robot.Chat.Publish(compose.MessageTo(ctx.channelName, message))
+	return ctx.robot.Chat.Publish(context.Background(), compose.MessageTo(ctx.channelName, message))
 }
 
 func (bot *Bot) makeCtx(channel string, event *ifunny.ChatEvent) (Context, error) {

--- a/bot/context.go
+++ b/bot/context.go
@@ -38,9 +38,9 @@ func (ctx *eventContext) Caller() (*ifunny.User, error) {
 	var user *ifunny.User
 	var err error
 	if ctx.event.User.ID != "" {
-		user, err = ctx.robot.Client.GetUser(compose.UserByID(ctx.event.User.ID))
+		user, err = ctx.robot.Client.GetUser(ctx.robot.ctx, compose.UserByID(ctx.event.User.ID))
 	} else {
-		user, err = ctx.robot.Client.GetUser(compose.UserByNick(ctx.event.User.Nick))
+		user, err = ctx.robot.Client.GetUser(ctx.robot.ctx, compose.UserByNick(ctx.event.User.Nick))
 	}
 
 	if err == nil {

--- a/bot/context.go
+++ b/bot/context.go
@@ -1,6 +1,8 @@
 package bot
 
 import (
+	"context"
+
 	"github.com/open-ifunny/ifunny-go"
 	"github.com/open-ifunny/ifunny-go/compose"
 )
@@ -38,9 +40,9 @@ func (ctx *eventContext) Caller() (*ifunny.User, error) {
 	var user *ifunny.User
 	var err error
 	if ctx.event.User.ID != "" {
-		user, err = ctx.robot.Client.GetUser(ctx.robot.ctx, compose.UserByID(ctx.event.User.ID))
+		user, err = ctx.robot.Client.GetUser(context.Background(), compose.UserByID(ctx.event.User.ID))
 	} else {
-		user, err = ctx.robot.Client.GetUser(ctx.robot.ctx, compose.UserByNick(ctx.event.User.Nick))
+		user, err = ctx.robot.Client.GetUser(context.Background(), compose.UserByNick(ctx.event.User.Nick))
 	}
 
 	if err == nil {

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -76,14 +76,14 @@ func (chat *Chat) handleChannelsRaw(handle func(eventType int, channel *ChatChan
 
 // OnChannelUpdate subscribes to channel join and invite events. The handler is called
 // with the event type and channel data. Returns an unsubscribe function.
-func (chat *Chat) OnChannelUpdate(handle func(eventType int, channel *ChatChannel) error) (func(), error) {
-	return chat.Subscribe(compose.JoinedChannels(chat.client.Self.ID), chat.handleChannelsRaw(handle))
+func (chat *Chat) OnChannelUpdate(ctx context.Context, handle func(eventType int, channel *ChatChannel) error) (func(), error) {
+	return chat.Subscribe(ctx, compose.JoinedChannels(chat.client.Self.ID), chat.handleChannelsRaw(handle))
 }
 
 // OnChannelInvite subscribes to channel invite events. The handler is called with the
 // event type and invited channel data. Returns an unsubscribe function.
-func (chat *Chat) OnChannelInvite(handle func(eventType int, channel *ChatChannel) error) (func(), error) {
-	return chat.Subscribe(compose.ReceiveInvite(chat.client.Self.ID), chat.handleChannelsRaw(handle))
+func (chat *Chat) OnChannelInvite(ctx context.Context, handle func(eventType int, channel *ChatChannel) error) (func(), error) {
+	return chat.Subscribe(ctx, compose.ReceiveInvite(chat.client.Self.ID), chat.handleChannelsRaw(handle))
 }
 
 // GetChannel executes a chat RPC call and unmarshals the result as a ChatChannel.
@@ -96,20 +96,20 @@ func (chat *Chat) OnChannelInvite(handle func(eventType int, channel *ChatChanne
 //
 // Example (fetch a public channel by name):
 //
-//	channel, err := chat.GetChannel(compose.GetChannel("chat.gamers"))
+//	channel, err := chat.GetChannel(ctx, compose.GetChannel("chat.gamers"))
 //	if err != nil {
 //		return err
 //	}
 //
 // Example (open a DM with another user):
 //
-//	channel, err := chat.GetChannel(compose.GetDMChannel(chat.client.Self.ID, "friend-id"))
-func (chat *Chat) GetChannel(call turnpike.Call) (*ChatChannel, error) {
+//	channel, err := chat.GetChannel(ctx, compose.GetDMChannel(chat.client.Self.ID, "friend-id"))
+func (chat *Chat) GetChannel(ctx context.Context, call turnpike.Call) (*ChatChannel, error) {
 	output := new(struct {
 		Chat *ChatChannel `json:"chat"`
 	})
 
-	err := chat.Call(call, output)
+	err := chat.Call(ctx, call, output)
 	return output.Chat, err
 }
 

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/gastrodon/turnpike"
 	"github.com/open-ifunny/ifunny-go/compose"
 	"github.com/sirupsen/logrus"
@@ -112,33 +114,33 @@ func (chat *Chat) GetChannel(call turnpike.Call) (*ChatChannel, error) {
 }
 
 // GetChannels fetches all chat channels matching the given request.
-func (client *Client) GetChannels(desc compose.Request) ([]*ChatChannel, error) {
+func (client *Client) GetChannels(ctx context.Context, desc compose.Request) ([]*ChatChannel, error) {
 	output := new(struct {
 		Data struct {
 			Channels []*ChatChannel `json:"channels"`
 		} `json:"data"`
 	})
 
-	err := client.RequestJSON(desc, output)
+	err := client.RequestJSON(ctx, desc, output)
 	return output.Data.Channels, err
 }
 
 // GetChannelsPage fetches a single page of chat channels given a composed request.
 // It is used internally by channel iteration methods and exported for advanced use cases.
-func (client *Client) GetChannelsPage(desc compose.Request) (*Page[ChatChannel], error) {
+func (client *Client) GetChannelsPage(ctx context.Context, desc compose.Request) (*Page[ChatChannel], error) {
 	output := new(struct {
 		Data struct {
 			Channels Page[ChatChannel] `json:"channels"`
 		} `json:"data"`
 	})
-	err := client.RequestJSON(desc, output)
+	err := client.RequestJSON(ctx, desc, output)
 	return &output.Data.Channels, err
 }
 
 // IterChannelsQuery returns a channel that yields chat channels matching a search query.
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterChannelsQuery(query string) <-chan Result[*ChatChannel] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterChannelsQuery(ctx context.Context, query string) <-chan Result[*ChatChannel] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.ChatsQuery(query, limit, page)
 	}, client.GetChannelsPage)
 }
@@ -148,17 +150,27 @@ func (client *Client) IterChannelsQuery(query string) <-chan Result[*ChatChannel
 // one-shot iterator: it delivers every trending channel and then closes. A
 // fetch error is delivered as a final Result with Err set before the channel
 // closes, matching the Result/close conventions of the paginated iterators.
-func (client *Client) IterChannelsTrending() <-chan Result[*ChatChannel] {
+func (client *Client) IterChannelsTrending(ctx context.Context) <-chan Result[*ChatChannel] {
 	data := make(chan Result[*ChatChannel])
+	send := func(r Result[*ChatChannel]) bool {
+		select {
+		case data <- r:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 	go func() {
 		defer close(data)
-		channels, err := client.GetChannels(compose.ChatsTrending)
+		channels, err := client.GetChannels(ctx, compose.ChatsTrending)
 		if err != nil {
-			data <- Result[*ChatChannel]{Err: err}
+			send(Result[*ChatChannel]{Err: err})
 			return
 		}
 		for _, channel := range channels {
-			data <- Result[*ChatChannel]{V: channel}
+			if !send(Result[*ChatChannel]{V: channel}) {
+				return
+			}
 		}
 	}()
 	return data

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -157,6 +157,11 @@ func (client *Client) IterChannelsTrending(ctx context.Context) <-chan Result[*C
 		case data <- r:
 			return true
 		case <-ctx.Done():
+			// Best-effort delivery of the cancellation, matching iterFrom.
+			select {
+			case data <- Result[*ChatChannel]{Err: ctx.Err()}:
+			default:
+			}
 			return false
 		}
 	}

--- a/chat-message.go
+++ b/chat-message.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/gastrodon/turnpike"
 	"github.com/google/uuid"
 	"github.com/open-ifunny/ifunny-go/compose"
@@ -40,8 +42,8 @@ type ChatEvent struct {
 
 // OnChannelEvent subscribes to messages in a channel. The handler is called for
 // each message or membership event. Returns an unsubscribe function.
-func (chat *Chat) OnChannelEvent(channel string, handle func(event *ChatEvent) error) (func(), error) {
-	return chat.Subscribe(compose.EventsIn(channel), func(eventType int, kwargs map[string]any) error {
+func (chat *Chat) OnChannelEvent(ctx context.Context, channel string, handle func(event *ChatEvent) error) (func(), error) {
+	return chat.Subscribe(ctx, compose.EventsIn(channel), func(eventType int, kwargs map[string]any) error {
 		log := chat.client.log.WithField("event_type", eventType)
 
 		if kwargs["message"] == nil {
@@ -67,24 +69,24 @@ func (chat *Chat) OnChannelEvent(channel string, handle func(event *ChatEvent) e
 //
 // Example (fetch the first page and one more):
 //
-//	msgs, _, next, err := chat.ListMessages(compose.ListMessages("chat.gamers", 30, compose.NoPage[int]()))
+//	msgs, _, next, err := chat.ListMessages(ctx, compose.ListMessages("chat.gamers", 30, compose.NoPage[int]()))
 //	if err != nil {
 //		return err
 //	}
 //	if next != 0 {
-//		more, _, _, err := chat.ListMessages(compose.ListMessages("chat.gamers", 30, compose.Next(next)))
+//		more, _, _, err := chat.ListMessages(ctx, compose.ListMessages("chat.gamers", 30, compose.Next(next)))
 //		_ = more
 //		_ = err
 //	}
 //	_ = msgs
-func (chat *Chat) ListMessages(desc turnpike.Call) ([]*ChatEvent, int64, int64, error) {
+func (chat *Chat) ListMessages(ctx context.Context, desc turnpike.Call) ([]*ChatEvent, int64, int64, error) {
 	output := new(struct {
 		Messages []*ChatEvent `json:"messages"`
 		Prev     int64        `json:"prev"`
 		Next     int64        `json:"next"`
 	})
 
-	err := chat.Call(desc, output)
+	err := chat.Call(ctx, desc, output)
 	return output.Messages, output.Prev, output.Next, err
 }
 
@@ -97,13 +99,13 @@ func (chat *Chat) ListMessages(desc turnpike.Call) ([]*ChatEvent, int64, int64, 
 //
 // Example (drain the entire history of a channel):
 //
-//	for result := range chat.IterMessages(compose.ListMessages("chat.gamers", 30, compose.NoPage[int]())) {
+//	for result := range chat.IterMessages(ctx, compose.ListMessages("chat.gamers", 30, compose.NoPage[int]())) {
 //		if result.Err != nil {
 //			return result.Err
 //		}
 //		fmt.Printf("[%s] %s\n", result.V.User.Nick, result.V.Text)
 //	}
-func (chat *Chat) IterMessages(desc turnpike.Call) <-chan Result[*ChatEvent] {
+func (chat *Chat) IterMessages(ctx context.Context, desc turnpike.Call) <-chan Result[*ChatEvent] {
 	data := make(chan Result[*ChatEvent])
 
 	traceID := uuid.New().String()
@@ -112,18 +114,34 @@ func (chat *Chat) IterMessages(desc turnpike.Call) <-chan Result[*ChatEvent] {
 		"channel":  desc.ArgumentsKw["chat_name"],
 	})
 
+	send := func(r Result[*ChatEvent]) bool {
+		select {
+		case data <- r:
+			return true
+		case <-ctx.Done():
+			// Best-effort delivery of the cancellation, matching iterFrom.
+			select {
+			case data <- Result[*ChatEvent]{Err: ctx.Err()}:
+			default:
+			}
+			return false
+		}
+	}
+
 	go func() {
 		defer close(data)
 		for {
-			buffer, _, next, err := chat.ListMessages(desc)
+			buffer, _, next, err := chat.ListMessages(ctx, desc)
 			if err != nil {
 				log.Trace("failed to get a message page, exiting")
-				data <- Result[*ChatEvent]{Err: err}
+				send(Result[*ChatEvent]{Err: err})
 				return
 			}
 
 			for _, event := range buffer {
-				data <- Result[*ChatEvent]{V: event}
+				if !send(Result[*ChatEvent]{V: event}) {
+					return
+				}
 			}
 
 			if next == 0 || len(buffer) == 0 {

--- a/chat.go
+++ b/chat.go
@@ -1,6 +1,7 @@
 package ifunny
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gastrodon/turnpike"
@@ -16,7 +17,7 @@ const (
 
 // Chat establishes a WebSocket connection to the iFunny chat API using the client's
 // bearer token. Returns an error if authentication or connection fails.
-func (client *Client) Chat() (*Chat, error) {
+func (client *Client) Chat(ctx context.Context) (*Chat, error) {
 	log := client.log.WithField("trace_id", uuid.New().String())
 
 	log.Trace("start connect chat")
@@ -28,7 +29,7 @@ func (client *Client) Chat() (*Chat, error) {
 
 	log.Trace("join realm ifunny")
 	ws.Auth = map[string]turnpike.AuthFunc{"ticket": turnpike.NewTicketAuthenticator(client.bearer)}
-	hello, err := ws.JoinRealm(string(compose.URI("ifunny")), nil)
+	hello, err := ws.JoinRealm(ctx, string(compose.URI("ifunny")), nil)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -73,15 +74,15 @@ func JSONDecode(data, output any) error {
 // Example (join a channel and discard the response):
 //
 //	var out struct{}
-//	if err := chat.Call(compose.JoinChannel("chat.gamers"), &out); err != nil {
+//	if err := chat.Call(ctx, compose.JoinChannel("chat.gamers"), &out); err != nil {
 //		return err
 //	}
 //
 // Example (invite users to a channel):
 //
 //	var out struct{}
-//	err := chat.Call(compose.Invite("chat.gamers", []string{"12345", "67890"}), &out)
-func (chat *Chat) Call(desc turnpike.Call, output any) error {
+//	err := chat.Call(ctx, compose.Invite("chat.gamers", []string{"12345", "67890"}), &out)
+func (chat *Chat) Call(ctx context.Context, desc turnpike.Call, output any) error {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
 		"type":     "CALL",
@@ -90,7 +91,7 @@ func (chat *Chat) Call(desc turnpike.Call, output any) error {
 	})
 
 	log.Trace("exec call")
-	result, err := chat.ws.Call(string(desc.Procedure), desc.Options, desc.Arguments, desc.ArgumentsKw)
+	result, err := chat.ws.Call(ctx, string(desc.Procedure), desc.Options, desc.Arguments, desc.ArgumentsKw)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -117,10 +118,10 @@ func (chat *Chat) Call(desc turnpike.Call, output any) error {
 //
 // Example (send a text message to a channel):
 //
-//	if err := chat.Publish(compose.MessageTo("chat.gamers", "gg")); err != nil {
+//	if err := chat.Publish(ctx, compose.MessageTo("chat.gamers", "gg")); err != nil {
 //		return err
 //	}
-func (chat *Chat) Publish(desc turnpike.Publish) error {
+func (chat *Chat) Publish(ctx context.Context, desc turnpike.Publish) error {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
 		"type":     "PUBLISH",
@@ -153,7 +154,7 @@ func (chat *Chat) Publish(desc turnpike.Publish) error {
 //
 // Example (raw subscription to a channel's events):
 //
-//	unsubscribe, err := chat.Subscribe(compose.EventsIn("chat.gamers"), func(eventType int, kwargs map[string]any) error {
+//	unsubscribe, err := chat.Subscribe(ctx, compose.EventsIn("chat.gamers"), func(eventType int, kwargs map[string]any) error {
 //		fmt.Printf("event %d: %+v\n", eventType, kwargs)
 //		return nil
 //	})
@@ -161,7 +162,7 @@ func (chat *Chat) Publish(desc turnpike.Publish) error {
 //		return err
 //	}
 //	defer unsubscribe()
-func (chat *Chat) Subscribe(desc turnpike.Subscribe, handle EventHandler) (func(), error) {
+func (chat *Chat) Subscribe(ctx context.Context, desc turnpike.Subscribe, handle EventHandler) (func(), error) {
 	log := chat.client.log.WithFields(logrus.Fields{
 		"trace_id": uuid.New().String(),
 		"type":     "SUBSCRIBE",
@@ -170,7 +171,7 @@ func (chat *Chat) Subscribe(desc turnpike.Subscribe, handle EventHandler) (func(
 	})
 
 	log.Trace("exec subscribe")
-	err := chat.ws.Subscribe(string(desc.Topic), desc.Options, func(args []any, kwargs map[string]any) {
+	err := chat.ws.Subscribe(ctx, string(desc.Topic), desc.Options, func(args []any, kwargs map[string]any) {
 		eType := 0
 		if err := JSONDecode(kwargs["type"], &eType); err != nil {
 			log.Error(err)
@@ -182,5 +183,5 @@ func (chat *Chat) Subscribe(desc turnpike.Subscribe, handle EventHandler) (func(
 		}
 	})
 
-	return func() { chat.ws.Unsubscribe(string(desc.Topic)) }, err
+	return func() { chat.ws.Unsubscribe(ctx, string(desc.Topic)) }, err
 }

--- a/client.go
+++ b/client.go
@@ -150,6 +150,7 @@ func request(ctx context.Context, apiRoot string, desc compose.Request, header h
 	}
 
 	if r.StatusCode >= 400 {
+		defer r.Body.Close()
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed collecting HTTP error: %s", err)

--- a/client.go
+++ b/client.go
@@ -201,6 +201,7 @@ func (client *Client) RequestJSON(ctx context.Context, desc compose.Request, out
 		log.Error(err)
 		return err
 	}
+	defer response.Body.Close()
 
 	log.Trace(fmt.Sprintf("got response %s", response.Status))
 	bodyBytes, err := io.ReadAll(response.Body)

--- a/client.go
+++ b/client.go
@@ -155,18 +155,26 @@ func request(ctx context.Context, apiRoot string, desc compose.Request, header h
 			return nil, fmt.Errorf("failed collecting HTTP error: %s", err)
 		}
 
-		unwrap := new(struct {
-			Msg []byte `json:"msg"`
-		})
-		if err := json.Unmarshal(b, unwrap); err != nil {
-			return nil, fmt.Errorf("failed to unwrap HTTP error: %s, body: %s", err, string(b))
-		}
-
 		apiErr := new(APIError)
-		if err := json.Unmarshal(b, apiErr); err != nil {
-			return nil, fmt.Errorf("failed to decode HTTP error: %s", err)
+		err = json.Unmarshal(b, apiErr)
+
+		// If JSON decode succeeded and we got at least a Kind or Description,
+		// treat it as a structured API error.
+		if err == nil && (apiErr.Kind != "" || apiErr.Description != "") {
+			// Fill in Status from the HTTP code if not present in the JSON.
+			if apiErr.Status == 0 {
+				apiErr.Status = r.StatusCode
+			}
+			return nil, apiErr
 		}
 
+		// JSON decode failed or the body is empty/zero. Fall back to a
+		// plain-text error using the HTTP status and the raw body.
+		apiErr = &APIError{
+			Status:      r.StatusCode,
+			Kind:        http.StatusText(r.StatusCode),
+			Description: strings.TrimSpace(string(b)),
+		}
 		return nil, apiErr
 	}
 

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package ifunny
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,11 +76,12 @@ func newClient(authorization string, ua UserAgent, opts ...Option) *Client {
 // MakeClient constructs an authenticated client using a bearer token. It fetches
 // the authenticated user's account data and stores it in the returned client's
 // Self field. Returns an error if authentication fails or the account fetch fails.
-func MakeClient(bearer string, ua UserAgent, opts ...Option) (*Client, error) {
+// The ctx governs the initial /account fetch.
+func MakeClient(ctx context.Context, bearer string, ua UserAgent, opts ...Option) (*Client, error) {
 	client := newClient("bearer "+bearer, ua, opts...)
 	client.bearer = bearer
 
-	self, err := client.GetUser(compose.UserAccount())
+	self, err := client.GetUser(ctx, compose.UserAccount())
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +136,8 @@ func AsAPIError(err error) (*APIError, bool) {
 	return nil, false
 }
 
-func request(apiRoot string, desc compose.Request, header http.Header, client *http.Client) (*http.Response, error) {
-	request, err := http.NewRequest(desc.Method, apiRoot+desc.Path, desc.Body)
+func request(ctx context.Context, apiRoot string, desc compose.Request, header http.Header, client *http.Client) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, desc.Method, apiRoot+desc.Path, desc.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -181,8 +183,9 @@ func (client *Client) header() http.Header {
 
 // RequestJSON executes a composed API request and unmarshals the response body
 // into output as JSON. Returns errors from the network request or JSON decoding.
-// API errors (HTTP >= 400) are returned as *APIError wrapped in error.
-func (client *Client) RequestJSON(desc compose.Request, output any) error {
+// API errors (HTTP >= 400) are returned as *APIError wrapped in error. The ctx
+// governs the underlying HTTP request and is honored for cancellation/deadlines.
+func (client *Client) RequestJSON(ctx context.Context, desc compose.Request, output any) error {
 	traceID := uuid.New().String()
 	log := client.log.WithFields(logrus.Fields{
 		"trace_id": traceID,
@@ -193,7 +196,7 @@ func (client *Client) RequestJSON(desc compose.Request, output any) error {
 	)
 
 	log.Trace("make request")
-	response, err := request(client.apiRoot, desc, client.header(), client.http)
+	response, err := request(ctx, client.apiRoot, desc, client.header(), client.http)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/client.go
+++ b/client.go
@@ -157,25 +157,12 @@ func request(ctx context.Context, apiRoot string, desc compose.Request, header h
 		}
 
 		apiErr := new(APIError)
-		err = json.Unmarshal(b, apiErr)
-
-		// If JSON decode succeeded and we got at least a Kind or Description,
-		// treat it as a structured API error.
-		if err == nil && (apiErr.Kind != "" || apiErr.Description != "") {
-			// Fill in Status from the HTTP code if not present in the JSON.
-			if apiErr.Status == 0 {
-				apiErr.Status = r.StatusCode
-			}
-			return nil, apiErr
+		if err := json.Unmarshal(b, apiErr); err != nil {
+			// Body isn't a structured API error (empty, plain text, etc.);
+			// surface the status and raw body without parsing around it.
+			return nil, fmt.Errorf("HTTP %d: %s", r.StatusCode, strings.TrimSpace(string(b)))
 		}
 
-		// JSON decode failed or the body is empty/zero. Fall back to a
-		// plain-text error using the HTTP status and the raw body.
-		apiErr = &APIError{
-			Status:      r.StatusCode,
-			Kind:        http.StatusText(r.StatusCode),
-			Description: strings.TrimSpace(string(b)),
-		}
 		return nil, apiErr
 	}
 
@@ -201,7 +188,8 @@ func (client *Client) RequestJSON(ctx context.Context, desc compose.Request, out
 		"path":     desc.Path,
 		"method":   desc.Method,
 		"query":    desc.Query.Encode(),
-		"has_body": desc.Body != nil},
+		"has_body": desc.Body != nil,
+	},
 	)
 
 	log.Trace("make request")

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package ifunny
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,7 +32,7 @@ func TestWithAPIRoot_RoutesRequestsToOverride(t *testing.T) {
 	// PrimeBasic hits /counters — we skip its 15s wait by not calling it here.
 	// Exercise RequestJSON directly against a composed request.
 	var out map[string]any
-	if err := client.RequestJSON(compose.UserAccount(), &out); err != nil {
+	if err := client.RequestJSON(context.Background(), compose.UserAccount(), &out); err != nil {
 		t.Fatalf("RequestJSON: %v", err)
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -68,3 +68,94 @@ func TestDefaultAPIRoot(t *testing.T) {
 		t.Errorf("default apiRoot = %q, want %q", c.apiRoot, DefaultAPIRoot)
 	}
 }
+
+// TestHTTPError_JSONBody confirms that structured JSON API errors are parsed
+// correctly, with Status filled from the HTTP code if not present in the JSON.
+func TestHTTPError_JSONBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"error":"invalid_request","error_description":"bad parameter"}`))
+	}))
+	defer srv.Close()
+
+	client, err := MakeClientBasic("dummy", Android{Version: "14"}.UserAgent(), WithAPIRoot(srv.URL))
+	if err != nil {
+		t.Fatalf("MakeClientBasic: %v", err)
+	}
+
+	var out map[string]any
+	err = client.RequestJSON(context.Background(), compose.UserAccount(), &out)
+	if err == nil {
+		t.Fatal("RequestJSON: expected error, got nil")
+	}
+
+	apiErr, ok := AsAPIError(err)
+	if !ok {
+		t.Fatalf("error is not *APIError: %T", err)
+	}
+
+	if apiErr.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", apiErr.Status, http.StatusBadRequest)
+	}
+	if apiErr.Kind != "invalid_request" {
+		t.Errorf("Kind = %q, want %q", apiErr.Kind, "invalid_request")
+	}
+	if apiErr.Description != "bad parameter" {
+		t.Errorf("Description = %q, want %q", apiErr.Description, "bad parameter")
+	}
+
+	// Confirm Error() produces a readable message.
+	errMsg := apiErr.Error()
+	if !strings.Contains(errMsg, "400") || !strings.Contains(errMsg, "invalid_request") {
+		t.Errorf("Error() = %q, want to contain '400' and 'invalid_request'", errMsg)
+	}
+}
+
+// TestHTTPError_PlainTextBody confirms that plain-text error bodies (e.g., CDN
+// responses like "Failure: 400 Bad Request") are handled gracefully and
+// returned as readable *APIError instead of JSON parse errors.
+func TestHTTPError_PlainTextBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("Failure: 400 Bad Request"))
+	}))
+	defer srv.Close()
+
+	client, err := MakeClientBasic("dummy", Android{Version: "14"}.UserAgent(), WithAPIRoot(srv.URL))
+	if err != nil {
+		t.Fatalf("MakeClientBasic: %v", err)
+	}
+
+	var out map[string]any
+	err = client.RequestJSON(context.Background(), compose.UserAccount(), &out)
+	if err == nil {
+		t.Fatal("RequestJSON: expected error, got nil")
+	}
+
+	apiErr, ok := AsAPIError(err)
+	if !ok {
+		t.Fatalf("error is not *APIError: %T", err)
+	}
+
+	if apiErr.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d, want %d", apiErr.Status, http.StatusBadRequest)
+	}
+	if apiErr.Kind != "Bad Request" {
+		t.Errorf("Kind = %q, want %q", apiErr.Kind, "Bad Request")
+	}
+	if apiErr.Description != "Failure: 400 Bad Request" {
+		t.Errorf("Description = %q, want %q", apiErr.Description, "Failure: 400 Bad Request")
+	}
+
+	// Confirm Error() produces a readable message (should NOT contain
+	// "failed to unwrap" or JSON parse errors).
+	errMsg := apiErr.Error()
+	if !strings.Contains(errMsg, "400") || !strings.Contains(errMsg, "Failure") {
+		t.Errorf("Error() = %q, want to contain '400' and 'Failure'", errMsg)
+	}
+	if strings.Contains(errMsg, "invalid character") || strings.Contains(errMsg, "failed to unwrap") {
+		t.Errorf("Error() = %q, should not contain parse errors", errMsg)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -69,13 +69,13 @@ func TestDefaultAPIRoot(t *testing.T) {
 	}
 }
 
-// TestHTTPError_JSONBody confirms that structured JSON API errors are parsed
-// correctly, with Status filled from the HTTP code if not present in the JSON.
+// TestHTTPError_JSONBody confirms that a structured JSON error body is decoded
+// into an *APIError and returned unaltered.
 func TestHTTPError_JSONBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"error":"invalid_request","error_description":"bad parameter"}`))
+		w.Write([]byte(`{"error":"invalid_request","error_description":"bad parameter","status":400}`))
 	}))
 	defer srv.Close()
 
@@ -104,17 +104,11 @@ func TestHTTPError_JSONBody(t *testing.T) {
 	if apiErr.Description != "bad parameter" {
 		t.Errorf("Description = %q, want %q", apiErr.Description, "bad parameter")
 	}
-
-	// Confirm Error() produces a readable message.
-	errMsg := apiErr.Error()
-	if !strings.Contains(errMsg, "400") || !strings.Contains(errMsg, "invalid_request") {
-		t.Errorf("Error() = %q, want to contain '400' and 'invalid_request'", errMsg)
-	}
 }
 
-// TestHTTPError_PlainTextBody confirms that plain-text error bodies (e.g., CDN
-// responses like "Failure: 400 Bad Request") are handled gracefully and
-// returned as readable *APIError instead of JSON parse errors.
+// TestHTTPError_PlainTextBody confirms that a non-JSON error body (e.g., a CDN
+// response like "Failure: 400 Bad Request") yields a generic error carrying the
+// HTTP status and the raw body, rather than an *APIError.
 func TestHTTPError_PlainTextBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -134,28 +128,12 @@ func TestHTTPError_PlainTextBody(t *testing.T) {
 		t.Fatal("RequestJSON: expected error, got nil")
 	}
 
-	apiErr, ok := AsAPIError(err)
-	if !ok {
-		t.Fatalf("error is not *APIError: %T", err)
+	if _, ok := AsAPIError(err); ok {
+		t.Fatalf("expected a generic error for a non-JSON body, got *APIError")
 	}
 
-	if apiErr.Status != http.StatusBadRequest {
-		t.Errorf("Status = %d, want %d", apiErr.Status, http.StatusBadRequest)
-	}
-	if apiErr.Kind != "Bad Request" {
-		t.Errorf("Kind = %q, want %q", apiErr.Kind, "Bad Request")
-	}
-	if apiErr.Description != "Failure: 400 Bad Request" {
-		t.Errorf("Description = %q, want %q", apiErr.Description, "Failure: 400 Bad Request")
-	}
-
-	// Confirm Error() produces a readable message (should NOT contain
-	// "failed to unwrap" or JSON parse errors).
-	errMsg := apiErr.Error()
-	if !strings.Contains(errMsg, "400") || !strings.Contains(errMsg, "Failure") {
-		t.Errorf("Error() = %q, want to contain '400' and 'Failure'", errMsg)
-	}
-	if strings.Contains(errMsg, "invalid character") || strings.Contains(errMsg, "failed to unwrap") {
-		t.Errorf("Error() = %q, should not contain parse errors", errMsg)
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "400") || !strings.Contains(errMsg, "Failure: 400 Bad Request") {
+		t.Errorf("Error() = %q, want to contain '400' and the raw body", errMsg)
 	}
 }

--- a/comment.go
+++ b/comment.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
@@ -54,40 +56,40 @@ type Comment struct {
 
 // GetCommentPage fetches a single page of comments given a composed request.
 // It is used internally by comment iteration methods and exported for advanced use cases.
-func (client *Client) GetCommentPage(request compose.Request) (*Page[Comment], error) {
+func (client *Client) GetCommentPage(ctx context.Context, request compose.Request) (*Page[Comment], error) {
 	content := new(struct {
 		Data struct {
 			Comments Page[Comment] `json:"comments"`
 		}
 	})
 
-	err := client.RequestJSON(request, content)
+	err := client.RequestJSON(ctx, request, content)
 	return &content.Data.Comments, err
 }
 
 // IterComments returns a channel that yields top-level comments on content (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterComments(id string) <-chan Result[*Comment] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Comments(id, limit, page) }, client.GetCommentPage)
+func (client *Client) IterComments(ctx context.Context, id string) <-chan Result[*Comment] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request { return compose.Comments(id, limit, page) }, client.GetCommentPage)
 }
 
 // GetRepliesPage fetches a single page of replies to a comment given a composed request.
 // It is used internally by reply iteration methods and exported for advanced use cases.
-func (client *Client) GetRepliesPage(request compose.Request) (*Page[Comment], error) {
+func (client *Client) GetRepliesPage(ctx context.Context, request compose.Request) (*Page[Comment], error) {
 	content := new(struct {
 		Data struct {
 			Replies Page[Comment] `json:"replies"`
 		} `json:"data"`
 	})
 
-	err := client.RequestJSON(request, content)
+	err := client.RequestJSON(ctx, request, content)
 	return &content.Data.Replies, err
 }
 
 // IterReplies returns a channel that yields replies to a specific comment (identified by cid on content id).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterReplies(cid, id string) <-chan Result[*Comment] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterReplies(ctx context.Context, cid, id string) <-chan Result[*Comment] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Replies(cid, id, limit, page)
 	}, client.GetRepliesPage)
 }

--- a/content.go
+++ b/content.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
@@ -80,57 +82,57 @@ type Cursor struct {
 }
 
 // GetContent fetches a single piece of content by ID.
-func (client *Client) GetContent(id string) (*Content, error) {
+func (client *Client) GetContent(ctx context.Context, id string) (*Content, error) {
 	content := new(struct {
 		Data Content `json:"data"`
 	})
-	err := client.RequestJSON(compose.ContentByID(id), content)
+	err := client.RequestJSON(ctx, compose.ContentByID(id), content)
 	return &content.Data, err
 }
 
 // GetFeedPage fetches a single page of content given a composed request. It is used
 // internally by feed iteration methods and is exported for advanced use cases.
-func (client *Client) GetFeedPage(request compose.Request) (*Page[Content], error) {
+func (client *Client) GetFeedPage(ctx context.Context, request compose.Request) (*Page[Content], error) {
 	content := new(struct {
 		Data struct {
 			Content Page[Content] `json:"content"`
 		} `json:"data"`
 	})
 
-	err := client.RequestJSON(request, content)
+	err := client.RequestJSON(ctx, request, content)
 	return &content.Data.Content, err
 }
 
 // IterFeed returns a channel that yields content from a named feed (e.g. "hot", "trending").
-// The iterator automatically fetches new pages as needed. Close the channel to stop iteration.
-func (client *Client) IterFeed(feed string) <-chan Result[*Content] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Feed(feed, limit, page) }, client.GetFeedPage)
+// The iterator automatically fetches new pages as needed. Cancel ctx to stop iteration.
+func (client *Client) IterFeed(ctx context.Context, feed string) <-chan Result[*Content] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request { return compose.Feed(feed, limit, page) }, client.GetFeedPage)
 }
 
 // IterTimeline returns a channel that yields content posted by a user (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterTimeline(id string) <-chan Result[*Content] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Timeline(id, limit, page) }, client.GetFeedPage)
+func (client *Client) IterTimeline(ctx context.Context, id string) <-chan Result[*Content] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request { return compose.Timeline(id, limit, page) }, client.GetFeedPage)
 }
 
 // IterTimelineByNick returns a channel that yields content posted by a user (identified by nick/username).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterTimelineByNick(nick string) <-chan Result[*Content] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterTimelineByNick(ctx context.Context, nick string) <-chan Result[*Content] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.TimelineByNick(nick, limit, page)
 	}, client.GetFeedPage)
 }
 
 // IterSmiles returns a channel that yields users who smiled at the content (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterSmiles(id string) <-chan Result[*User] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request { return compose.Smiles(id, limit, page) }, client.GetUsersPage)
+func (client *Client) IterSmiles(ctx context.Context, id string) <-chan Result[*User] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request { return compose.Smiles(id, limit, page) }, client.GetUsersPage)
 }
 
 // IterRepublishers returns a channel that yields users who republished the content (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterRepublishers(id string) <-chan Result[*User] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterRepublishers(ctx context.Context, id string) <-chan Result[*User] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Republished(id, limit, page)
 	}, client.GetUsersPage)
 }

--- a/examples/chat-iter/main.go
+++ b/examples/chat-iter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -17,10 +18,11 @@ func printChannel(c *ifunny.ChatChannel) {
 
 func main() {
 	q := "hello"
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
 
 	fmt.Printf("iterating results for q=%s\n", q)
-	iter := client.IterChannelsQuery(q)
+	iter := client.IterChannelsQuery(ctx, q)
 	for i := 0; i < 60; i++ {
 		r := <-iter
 		if r.Err != nil {

--- a/examples/chat-messages/main.go
+++ b/examples/chat-messages/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,10 +13,11 @@ var bearer = os.Getenv("IFUNNY_BEARER")
 var userAgent = os.Getenv("IFUNNY_USER_AGENT")
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
 	chat, _ := client.Chat()
 
-	channels, err := client.GetChannels(compose.ChatsTrending)
+	channels, err := client.GetChannels(ctx, compose.ChatsTrending)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/chat-messages/main.go
+++ b/examples/chat-messages/main.go
@@ -15,7 +15,7 @@ var userAgent = os.Getenv("IFUNNY_USER_AGENT")
 func main() {
 	ctx := context.Background()
 	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
-	chat, _ := client.Chat()
+	chat, _ := client.Chat(ctx)
 
 	channels, err := client.GetChannels(ctx, compose.ChatsTrending)
 	if err != nil {
@@ -24,7 +24,7 @@ func main() {
 
 	fmt.Printf("got %d trendy chat channels!\n", len(channels))
 
-	messages, _, _, err := chat.ListMessages(compose.ListMessages("apitools", 10, compose.NoPage[int]()))
+	messages, _, _, err := chat.ListMessages(ctx, compose.ListMessages("apitools", 10, compose.NoPage[int]()))
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +34,7 @@ func main() {
 		fmt.Printf("[%.0f] %s: %s\n", m.PubAt, m.User.Nick, m.Text)
 	}
 
-	messages, _, _, err = chat.ListMessages(compose.ListMessages("apitools", 10, compose.Prev(0)))
+	messages, _, _, err = chat.ListMessages(ctx, compose.ListMessages("apitools", 10, compose.Prev(0)))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/comment/main.go
+++ b/examples/comment/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -17,8 +18,9 @@ func printComment(c *ifunny.Comment) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
-	comments, err := client.GetCommentPage(compose.Comments("r4mB8i4NA", 30, compose.NoPage[string]()))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
+	comments, err := client.GetCommentPage(ctx, compose.Comments("r4mB8i4NA", 30, compose.NoPage[string]()))
 	if err != nil {
 		panic(err)
 	}
@@ -27,12 +29,12 @@ func main() {
 		printComment(&c)
 	}
 
-	featured, err := client.GetFeedPage(compose.Feed("featured", 1, compose.NoPage[string]()))
+	featured, err := client.GetFeedPage(ctx, compose.Feed("featured", 1, compose.NoPage[string]()))
 	if err != nil {
 		panic(err)
 	}
 
-	data := client.IterComments(featured.Items[0].ID)
+	data := client.IterComments(ctx, featured.Items[0].ID)
 	for i := 0; i < 60; i++ {
 		r := <-data
 		if r.Err != nil {

--- a/examples/content-iter/main.go
+++ b/examples/content-iter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -16,10 +17,11 @@ func printContent(c *ifunny.Content) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
 
 	fmt.Println("iterating features")
-	iter := client.IterFeed("featured")
+	iter := client.IterFeed(ctx, "featured")
 	for i := 0; i < 60; i++ {
 		r := <-iter
 		if r.Err != nil {
@@ -34,7 +36,7 @@ func main() {
 	}
 
 	fmt.Println("iterating our timeline")
-	iter = client.IterTimeline(client.Self.ID)
+	iter = client.IterTimeline(ctx, client.Self.ID)
 	for i := 0; i < 60; i++ {
 		r := <-iter
 		if r.Err != nil {

--- a/examples/content/main.go
+++ b/examples/content/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -17,8 +18,9 @@ func printContent(c *ifunny.Content) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
-	content, err := client.GetContent("lgzM46Im9")
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
+	content, err := client.GetContent(ctx, "lgzM46Im9")
 	if err != nil {
 		panic(err)
 	}
@@ -26,7 +28,7 @@ func main() {
 	printContent(content)
 
 	feed := "featured"
-	page, err := client.GetFeedPage(compose.Feed(feed, 5, compose.NoPage[string]()))
+	page, err := client.GetFeedPage(ctx, compose.Feed(feed, 5, compose.NoPage[string]()))
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +42,7 @@ func main() {
 		fmt.Println("that was the end of the feed")
 	}
 
-	page, err = client.GetFeedPage(compose.Feed(feed, 5, compose.Next(page.Paging.Cursors.Next)))
+	page, err = client.GetFeedPage(ctx, compose.Feed(feed, 5, compose.Next(page.Paging.Cursors.Next)))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explore/main.go
+++ b/examples/explore/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -21,9 +22,10 @@ func printUser(u *ifunny.User) {
 }
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
 
-	page, err := client.ExploreContentPage(compose.Explore("content_shuffle", 30, compose.NoPage[string]()))
+	page, err := client.ExploreContentPage(ctx, compose.Explore("content_shuffle", 30, compose.NoPage[string]()))
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +35,7 @@ func main() {
 		printContent(&c)
 	}
 
-	contentIter := client.IterExploreContent("category-science-tech")
+	contentIter := client.IterExploreContent(ctx, "category-science-tech")
 	for i := 0; i < 120; i++ {
 		r := <-contentIter
 		if r.Err != nil {
@@ -48,7 +50,7 @@ func main() {
 		printContent(r.V)
 	}
 
-	userIter := client.IterExploreUser("users_top_by_subscribers")
+	userIter := client.IterExploreUser(ctx, "users_top_by_subscribers")
 	for i := 0; i < 60; i++ {
 		r := <-userIter
 		if r.Err != nil {

--- a/examples/user/main.go
+++ b/examples/user/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,8 +13,9 @@ var bearer = os.Getenv("IFUNNY_BEARER")
 var userAgent = os.Getenv("IFUNNY_USER_AGENT")
 
 func main() {
-	client, _ := ifunny.MakeClient(bearer, ifunny.RawUserAgent(userAgent))
-	u, err := client.GetUser(compose.UserByNick("gastrodon"))
+	ctx := context.Background()
+	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
+	u, err := client.GetUser(ctx, compose.UserByNick("gastrodon"))
 	if err != nil {
 		panic(err)
 	}

--- a/explore.go
+++ b/explore.go
@@ -1,8 +1,12 @@
 package ifunny
 
-import "github.com/open-ifunny/ifunny-go/compose"
+import (
+	"context"
 
-func explorePage[T Content | User | ChatChannel](client *Client, request compose.Request) (*Page[T], error) {
+	"github.com/open-ifunny/ifunny-go/compose"
+)
+
+func explorePage[T Content | User | ChatChannel](ctx context.Context, client *Client, request compose.Request) (*Page[T], error) {
 	content := new(struct {
 		Data struct {
 			Value struct {
@@ -11,52 +15,55 @@ func explorePage[T Content | User | ChatChannel](client *Client, request compose
 		} `json:"data"`
 	})
 
-	err := client.RequestJSON(request, content)
+	err := client.RequestJSON(ctx, request, content)
 	return &content.Data.Value.Context, err
 }
 
 // ExploreContentPage fetches a single page of explore content given a composed request.
 // It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreContentPage(requet compose.Request) (*Page[Content], error) {
-	return explorePage[Content](client, requet)
+func (client *Client) ExploreContentPage(ctx context.Context, requet compose.Request) (*Page[Content], error) {
+	return explorePage[Content](ctx, client, requet)
 }
 
 // ExploreUserPage fetches a single page of explore users given a composed request.
 // It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreUserPage(requet compose.Request) (*Page[User], error) {
-	return explorePage[User](client, requet)
+func (client *Client) ExploreUserPage(ctx context.Context, requet compose.Request) (*Page[User], error) {
+	return explorePage[User](ctx, client, requet)
 }
 
 // ExploreChatChannelPage fetches a single page of explore chat channels given a composed request.
 // It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreChatChannelPage(requet compose.Request) (*Page[ChatChannel], error) {
-	return explorePage[ChatChannel](client, requet)
+func (client *Client) ExploreChatChannelPage(ctx context.Context, requet compose.Request) (*Page[ChatChannel], error) {
+	return explorePage[ChatChannel](ctx, client, requet)
 }
 
-func iterExplore[T Content | User | ChatChannel](client *Client, compilation string) <-chan Result[*T] {
+func iterExplore[T Content | User | ChatChannel](ctx context.Context, client *Client, compilation string) <-chan Result[*T] {
 	return iterFrom(
+		ctx,
 		client,
 		func(limit int, page compose.Page[string]) compose.Request {
 			return compose.Explore(compilation, limit, page)
 		},
-		func(request compose.Request) (*Page[T], error) { return explorePage[T](client, request) },
+		func(ctx context.Context, request compose.Request) (*Page[T], error) {
+			return explorePage[T](ctx, client, request)
+		},
 	)
 }
 
 // IterExploreContent returns a channel that yields content from an explore compilation.
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterExploreContent(compilation string) <-chan Result[*Content] {
-	return iterExplore[Content](client, compilation)
+func (client *Client) IterExploreContent(ctx context.Context, compilation string) <-chan Result[*Content] {
+	return iterExplore[Content](ctx, client, compilation)
 }
 
 // IterExploreUser returns a channel that yields users from an explore compilation.
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterExploreUser(compilation string) <-chan Result[*User] {
-	return iterExplore[User](client, compilation)
+func (client *Client) IterExploreUser(ctx context.Context, compilation string) <-chan Result[*User] {
+	return iterExplore[User](ctx, client, compilation)
 }
 
 // IterExploreChatChannel returns a channel that yields chat channels from an explore compilation.
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterExploreChatChannel(compilation string) <-chan Result[*ChatChannel] {
-	return iterExplore[ChatChannel](client, compilation)
+func (client *Client) IterExploreChatChannel(ctx context.Context, compilation string) <-chan Result[*ChatChannel] {
+	return iterExplore[ChatChannel](ctx, client, compilation)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-ifunny/ifunny-go
 go 1.22.1
 
 require (
-	github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5
+	github.com/gastrodon/turnpike v1.2.0
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-ifunny/ifunny-go
 go 1.22.1
 
 require (
-	github.com/gastrodon/turnpike v1.1.0
+	github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gastrodon/turnpike v1.1.0 h1:BWKVeUFruClO7Oh4Un3bGk2O8RySgaXWWy4ZkB7CSrI=
-github.com/gastrodon/turnpike v1.1.0/go.mod h1:Awtmr4/Gy1p2P1PIVdO7cf3QiafNxVy5vpTAsqrkjKY=
+github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5 h1:gDF/DPQCpowLWcs5Y2x+utcYAFQHKjxrZKOxfe5vL2I=
+github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5/go.mod h1:fLN3ul3N22YFIS+3dHI5ndR+C85TPorqd1scza8NioQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20161023184700-6f5a3c4a73ba h1:xryw1OKbAIiEjwQM4TUdIvOLolJK5/LjhEE9pFu4j70=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5 h1:gDF/DPQCpowLWcs5Y2x+utcYAFQHKjxrZKOxfe5vL2I=
-github.com/gastrodon/turnpike v1.1.1-0.20260717164209-4ba6aaf4e2c5/go.mod h1:fLN3ul3N22YFIS+3dHI5ndR+C85TPorqd1scza8NioQ=
+github.com/gastrodon/turnpike v1.2.0 h1:ug51VXeni3/nfS0v4cdWPnzUpOJI4eiSihzUplj2H9o=
+github.com/gastrodon/turnpike v1.2.0/go.mod h1:fLN3ul3N22YFIS+3dHI5ndR+C85TPorqd1scza8NioQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20161023184700-6f5a3c4a73ba h1:xryw1OKbAIiEjwQM4TUdIvOLolJK5/LjhEE9pFu4j70=

--- a/iter.go
+++ b/iter.go
@@ -17,7 +17,10 @@ type Page[T Comment | Content | User | ChatChannel] struct {
 
 // Result carries one item from an iterator or an error. Iterators close their
 // channel when done; a mid-iteration failure is delivered as a final Result
-// with Err set (and V zero-valued) before the channel closes.
+// with Err set (and V zero-valued) before the channel closes. Cancelling the
+// iterator's ctx delivers a final Result with Err = ctx.Err() on a best-effort
+// basis: it is sent only if the consumer is still receiving, so a consumer
+// that cancels and walks away never blocks the pager goroutine.
 type Result[T any] struct {
 	V   T
 	Err error
@@ -42,12 +45,18 @@ func iterFrom[T Content | Comment | User | ChatChannel](ctx context.Context, cli
 
 	// send delivers r on data, but bails out if ctx is cancelled so a
 	// downstream consumer that stops reading (or a cancelled request)
-	// never leaks this goroutine on a blocked send.
+	// never leaks this goroutine on a blocked send. On cancellation it
+	// makes a best-effort (non-blocking) delivery of ctx.Err() so a
+	// still-listening consumer can tell cancellation from exhaustion.
 	send := func(r Result[*T]) bool {
 		select {
 		case data <- r:
 			return true
 		case <-ctx.Done():
+			select {
+			case data <- Result[*T]{Err: ctx.Err()}:
+			default:
+			}
 			return false
 		}
 	}

--- a/iter.go
+++ b/iter.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/google/uuid"
 	"github.com/open-ifunny/ifunny-go/compose"
 	"github.com/sirupsen/logrus"
@@ -29,7 +31,7 @@ type Iterator[T any] struct {
 	Stop func()
 }
 
-func iterFrom[T Content | Comment | User | ChatChannel](client *Client, composer func(limit int, page compose.Page[string]) compose.Request, feeder func(compose.Request) (*Page[T], error)) <-chan Result[*T] {
+func iterFrom[T Content | Comment | User | ChatChannel](ctx context.Context, client *Client, composer func(limit int, page compose.Page[string]) compose.Request, feeder func(context.Context, compose.Request) (*Page[T], error)) <-chan Result[*T] {
 	page := compose.NoPage[string]()
 	data := make(chan Result[*T])
 
@@ -38,19 +40,33 @@ func iterFrom[T Content | Comment | User | ChatChannel](client *Client, composer
 		"trace_id": traceID,
 	})
 
+	// send delivers r on data, but bails out if ctx is cancelled so a
+	// downstream consumer that stops reading (or a cancelled request)
+	// never leaks this goroutine on a blocked send.
+	send := func(r Result[*T]) bool {
+		select {
+		case data <- r:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
 	go func() {
 		defer close(data)
 		for {
 			log.Trace("buffering a feed page")
-			items, err := feeder(composer(30, page))
+			items, err := feeder(ctx, composer(30, page))
 			if err != nil {
 				log.Trace("failed to get a feed page, exiting")
-				data <- Result[*T]{Err: err}
+				send(Result[*T]{Err: err})
 				return
 			}
 
 			for i := range items.Items {
-				data <- Result[*T]{V: &items.Items[i]}
+				if !send(Result[*T]{V: &items.Items[i]}) {
+					return
+				}
 			}
 
 			log.Tracef("next: %s, has next: %t",

--- a/iter_test.go
+++ b/iter_test.go
@@ -1,0 +1,130 @@
+package ifunny
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// feedPageJSON is a GetFeedPage-shaped response with two items and hasNext=true,
+// so an iterator against it pages forever until stopped.
+const feedPageJSON = `{"data":{"content":{"items":[{"id":"a"},{"id":"b"}],"paging":{"cursors":{"next":"n"},"hasNext":true}}}}`
+
+func testClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := MakeClientBasic("dummy", Android{Version: "14"}.UserAgent(), WithAPIRoot(srv.URL))
+	if err != nil {
+		t.Fatalf("MakeClientBasic: %v", err)
+	}
+	return client
+}
+
+// TestIterFeed_CancelClosesChannel confirms that cancelling the ctx of an
+// otherwise-infinite pager tears it down: the result channel closes promptly
+// instead of the pager goroutine leaking on a blocked send.
+func TestIterFeed_CancelClosesChannel(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(feedPageJSON))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	iter := client.IterFeed(ctx, "featured")
+
+	// Consume one item to prove the pager is live, then cancel.
+	if r := <-iter; r.Err != nil {
+		t.Fatalf("first result: %v", r.Err)
+	}
+	cancel()
+
+	// Drain: the channel must close promptly. Any post-cancel error result
+	// must be the ctx error, not a fabricated one.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case r, ok := <-iter:
+			if !ok {
+				return // closed: pager exited
+			}
+			if r.Err != nil && !errors.Is(r.Err, context.Canceled) {
+				t.Fatalf("post-cancel error = %v, want context.Canceled", r.Err)
+			}
+		case <-deadline:
+			t.Fatal("iterator did not close within 2s of cancel")
+		}
+	}
+}
+
+// TestIterFeed_CancelMidFetchDeliversCtxErr cancels while the pager is blocked
+// on an in-flight HTTP request, and asserts a still-listening consumer receives
+// a final Result carrying context.Canceled before the channel closes — i.e.
+// cancellation is distinguishable from feed exhaustion.
+func TestIterFeed_CancelMidFetchDeliversCtxErr(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // block until the request is cancelled
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	iter := client.IterFeed(ctx, "featured")
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	var sawCanceled bool
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case r, ok := <-iter:
+			if !ok {
+				if !sawCanceled {
+					t.Fatal("channel closed without delivering context.Canceled")
+				}
+				return
+			}
+			if !errors.Is(r.Err, context.Canceled) {
+				t.Fatalf("result error = %v, want context.Canceled", r.Err)
+			}
+			sawCanceled = true
+		case <-deadline:
+			t.Fatal("iterator did not close within 2s of cancel")
+		}
+	}
+}
+
+// TestIterChannelsTrending_CancelMidFetchDeliversCtxErr is the same mid-fetch
+// cancellation contract for the one-shot trending iterator.
+func TestIterChannelsTrending_CancelMidFetchDeliversCtxErr(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	iter := client.IterChannelsTrending(ctx)
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	var sawCanceled bool
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case r, ok := <-iter:
+			if !ok {
+				if !sawCanceled {
+					t.Fatal("channel closed without delivering context.Canceled")
+				}
+				return
+			}
+			if !errors.Is(r.Err, context.Canceled) {
+				t.Fatalf("result error = %v, want context.Canceled", r.Err)
+			}
+			sawCanceled = true
+		case <-deadline:
+			t.Fatal("iterator did not close within 2s of cancel")
+		}
+	}
+}

--- a/user.go
+++ b/user.go
@@ -1,6 +1,8 @@
 package ifunny
 
 import (
+	"context"
+
 	"github.com/gastrodon/turnpike"
 	"github.com/open-ifunny/ifunny-go/compose"
 )
@@ -40,12 +42,12 @@ type User struct {
 }
 
 // GetUser fetches a single user given a composed request (e.g. compose.UserAccount() for the authenticated user).
-func (client *Client) GetUser(desc compose.Request) (*User, error) {
+func (client *Client) GetUser(ctx context.Context, desc compose.Request) (*User, error) {
 	user := new(struct {
 		Data User `json:"data"`
 	})
 
-	err := client.RequestJSON(desc, user)
+	err := client.RequestJSON(ctx, desc, user)
 	return &user.Data, err
 }
 
@@ -54,29 +56,29 @@ func (client *Client) GetUser(desc compose.Request) (*User, error) {
 // It is used internally by user iteration methods and exported for advanced use cases.
 // These endpoints return a reduced projection of User (no email/privacy fields);
 // absent fields are simply zero-valued.
-func (client *Client) GetUsersPage(request compose.Request) (*Page[User], error) {
+func (client *Client) GetUsersPage(ctx context.Context, request compose.Request) (*Page[User], error) {
 	users := new(struct {
 		Data struct {
 			Users Page[User] `json:"users"`
 		} `json:"data"`
 	})
 
-	err := client.RequestJSON(request, users)
+	err := client.RequestJSON(ctx, request, users)
 	return &users.Data.Users, err
 }
 
 // IterSubscribers returns a channel that yields users who follow the user (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterSubscribers(id string) <-chan Result[*User] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterSubscribers(ctx context.Context, id string) <-chan Result[*User] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Subscribers(id, limit, page)
 	}, client.GetUsersPage)
 }
 
 // IterSubscriptions returns a channel that yields users followed by the user (identified by ID).
 // The iterator automatically fetches new pages as needed.
-func (client *Client) IterSubscriptions(id string) <-chan Result[*User] {
-	return iterFrom(client, func(limit int, page compose.Page[string]) compose.Request {
+func (client *Client) IterSubscriptions(ctx context.Context, id string) <-chan Result[*User] {
+	return iterFrom(ctx, client, func(limit int, page compose.Page[string]) compose.Request {
 		return compose.Subscriptions(id, limit, page)
 	}, client.GetUsersPage)
 }

--- a/user.go
+++ b/user.go
@@ -94,19 +94,19 @@ func (client *Client) IterSubscriptions(ctx context.Context, id string) <-chan R
 //
 // Example (list your first 50 contacts):
 //
-//	users, err := chat.GetUsers(compose.Contacts(50))
+//	users, err := chat.GetUsers(ctx, compose.Contacts(50))
 //	if err != nil {
 //		return err
 //	}
 //
 // Example (list the operators of a channel):
 //
-//	ops, err := chat.GetUsers(compose.Operators("chat.gamers"))
-func (chat *Chat) GetUsers(desc turnpike.Call) ([]*User, error) {
+//	ops, err := chat.GetUsers(ctx, compose.Operators("chat.gamers"))
+func (chat *Chat) GetUsers(ctx context.Context, desc turnpike.Call) ([]*User, error) {
 	output := new(struct {
 		Users []*User `json:"users"`
 	})
 
-	err := chat.Call(desc, output)
+	err := chat.Call(ctx, desc, output)
 	return output.Users, err
 }


### PR DESCRIPTION
## Summary
- Every request-making method on `*Client` (`GetContent`, `GetUser`, `GetUsersPage`, `GetCommentPage`, `GetRepliesPage`, `Explore*Page`, `GetChannels`/`GetChannelsPage`, all `Iter*`) now takes `ctx context.Context` as its first argument and builds requests via `http.NewRequestWithContext`, so callers can cancel or deadline API calls.
- `iterFrom` and `IterChannelsTrending` guard their channel sends on `ctx.Done`, so a cancelled ctx unblocks and tears down an in-flight pager goroutine instead of leaking it on a blocked send.
- `PrimeBasic`'s ~15s wait is now cancellable (`select` on `ctx.Done`).
- `MakeClient` takes a ctx for the construction-time `/account` fetch. `bot.MakeBot` is unchanged (no ctx param): the bot uses `context.Background()` internally for construction and per-event `Caller()` lookups, since bot-level cancellation is out of scope for this PR.
- `RequestJSON` now closes the response body (`defer response.Body.Close()`) once it starts building requests with an explicit ctx, so a cancelled/erroring request doesn't leak the underlying connection.
- `MakeClientBasic`/`GenerateBasic` are unchanged — they do no network I/O.

## Motivation
Downstream (psyduck-etl/ifunny streaming transformers) cancels a transformer's context to abort work, but in-flight HTTP calls could not observe it because requests were built with `http.NewRequest` (effectively `context.Background()`). This threads real cancellation end to end.

## Breaking change
API surface changes on nearly every `*Client` accessor — intended for **v0.2.0**. Callers add a leading `ctx` arg; examples, README, and tests are all updated in this PR. `bot.MakeBot`'s signature is unaffected.

## Test plan
- [x] `go build ./...` and `go build -tags=integration ./...`
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./... -race -count=1` green
- [ ] Live integration (`-tags=integration`, needs `IFUNNY_INTEGRATION_NICK` + network) — not run here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
