### PR TITLE
Add missing content kinds and a typed Payload abstraction

### DIFF
--- a/content.go
+++ b/content.go
@@ -77,29 +77,29 @@ type Content struct {
 	} `json:"creator"`
 
 	// Populated when Type == CONTENT_PIC.
-	Pic *PicPayload `json:"pic,omitempty"`
+	Pic *PayloadPic `json:"pic,omitempty"`
 	// Populated when Type == CONTENT_COMICS. Same shape as Pic; comics are
 	// just images produced by a different in-app creator.
-	Comics *PicPayload `json:"comics,omitempty"`
+	Comics *PayloadPic `json:"comics,omitempty"`
 	// Populated when Type == CONTENT_MEME. Same shape as Pic; memes come
 	// from iFunny's legacy "Meme" creator.
-	Meme *PicPayload `json:"mem,omitempty"`
+	Meme *PayloadPic `json:"mem,omitempty"`
 	// Populated when Type == CONTENT_VIDEO_CLIP.
-	VideoClip *VideoClipPayload `json:"video_clip,omitempty"`
+	VideoClip *PayloadVideoClip `json:"video_clip,omitempty"`
 	// Populated when Type == CONTENT_VIDEO.
-	Video *VideoPayload `json:"video,omitempty"`
+	Video *PayloadVideo `json:"video,omitempty"`
 	// Populated when Type == CONTENT_VINE.
-	Vine *VinePayload `json:"vine,omitempty"`
+	Vine *PayloadVine `json:"vine,omitempty"`
 	// Populated when Type == CONTENT_COUB.
-	Coub *CoubPayload `json:"coub,omitempty"`
+	Coub *PayloadCoub `json:"coub,omitempty"`
 	// Populated when Type is CONTENT_GIF or CONTENT_GIF_CAPTION. The API
 	// uses the same "gif" key for both; CaptionText is only meaningful
 	// (non-empty) for CONTENT_GIF_CAPTION.
-	Gif *GifPayload `json:"gif,omitempty"`
+	Gif *PayloadGif `json:"gif,omitempty"`
 	// Populated when Type == CONTENT_CAPTION.
-	Caption *CaptionPayload `json:"caption,omitempty"`
+	Caption *PayloadCaption `json:"caption,omitempty"`
 	// Populated when Type == CONTENT_APP.
-	App *AppPayload `json:"app,omitempty"`
+	App *PayloadApp `json:"app,omitempty"`
 }
 
 // Payload returns the kind-specific data for c as a Payload, chosen by

--- a/content.go
+++ b/content.go
@@ -6,26 +6,47 @@ import (
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
-// TODO types of content, missing a bunch of content types
-// an enum type when we have all of them ( will we ever? )
-// Content types returned by the API.
+// ContentKind identifies the shape of a piece of Content: what was actually
+// posted, and therefore which field on Content (Pic, VideoClip, Gif, ...)
+// holds its payload. It's a defined string type rather than a bag of
+// untyped constants so switches over it can be exhaustiveness-checked by
+// linters such as exhaustive.
+type ContentKind string
+
+// Content kinds returned by the API. Cross-checked against
+// github.com/MakeShiftArtist/ifunny-api-types (src/payloads/content.ts),
+// which documents kinds beyond the three iFunny's own docs mention.
 const (
-	CONTENT_PIC        = "pic"        // Picture/image content
-	CONTENT_VIDEO_CLIP = "video_clip" // Video content
-	CONTENT_COMICS     = "comics"     // created from the in-app comic maker
+	CONTENT_PIC         ContentKind = "pic"         // image meme; payload in Content.Pic
+	CONTENT_COMICS      ContentKind = "comics"      // made with the in-app comic maker; payload in Content.Comics
+	CONTENT_MEME        ContentKind = "mem"         // made with iFunny's legacy "Meme" creator; payload in Content.Meme
+	CONTENT_VIDEO_CLIP  ContentKind = "video_clip"  // most common video kind; payload in Content.VideoClip
+	CONTENT_VIDEO       ContentKind = "video"       // imported from a URL (e.g. YouTube); payload in Content.Video
+	CONTENT_VINE        ContentKind = "vine"        // legacy Vine import; payload in Content.Vine
+	CONTENT_COUB        ContentKind = "coub"        // imported from coub.com; payload in Content.Coub
+	CONTENT_GIF         ContentKind = "gif"         // plain gif; payload in Content.Gif
+	CONTENT_GIF_CAPTION ContentKind = "gif_caption" // captioned gif; shares Content.Gif with CONTENT_GIF
+	CONTENT_CAPTION     ContentKind = "caption"     // captioned image meme; payload in Content.Caption
+	CONTENT_APP         ContentKind = "app"         // interactive/iframe card, deprecated by iFunny; payload in Content.App
+	CONTENT_OLD         ContentKind = "old"         // ? undocumented, deprecated; no known payload
+	CONTENT_DEM         ContentKind = "dem"         // ? undocumented, deprecated; no known payload
+	CONTENT_SPECIAL     ContentKind = "special"     // ? undocumented; no known payload
 )
 
-// Content represents a post (image, video, or comic) on iFunny. It includes metadata
-// like creation date, stats (smiles, comments), and the creator's information.
+// Content represents a post (image, video, gif, ...) on iFunny. It includes
+// metadata like creation date, stats (smiles, comments), and the creator's
+// information. The kind-specific data describing what was actually posted
+// lives in one of the Pic/VideoClip/Gif/... fields, selected by Type; use
+// Payload to fetch it generically.
 type Content struct {
-	Type        string   `json:"type"`
-	ID          string   `json:"id"`
-	Link        string   `json:"link"`
-	DateCreated int64    `json:"date_created"`
-	PublushAt   int64    `json:"publish_at"`
-	Tags        []string `json:"tags"`
-	State       string   `json:"state"`
-	ShotStatus  string   `json:"shot_status"`
+	Type        ContentKind `json:"type"`
+	ID          string      `json:"id"`
+	Link        string      `json:"link"`
+	DateCreated int64       `json:"date_created"`
+	PublushAt   int64       `json:"publish_at"`
+	Tags        []string    `json:"tags"`
+	State       string      `json:"state"`
+	ShotStatus  string      `json:"shot_status"`
 
 	FastStart  bool `json:"fast_start"`
 	IsFeatured bool `json:"is_featured"`
@@ -55,18 +76,83 @@ type Content struct {
 		Nick string `json:"nick"`
 	} `json:"creator"`
 
-	// type = pic|comics
-	Pic struct {
-		WebpURL string `json:"webp_url"`
-	} `json:"pic,omitempty"`
+	// Populated when Type == CONTENT_PIC.
+	Pic *PicPayload `json:"pic,omitempty"`
+	// Populated when Type == CONTENT_COMICS. Same shape as Pic; comics are
+	// just images produced by a different in-app creator.
+	Comics *PicPayload `json:"comics,omitempty"`
+	// Populated when Type == CONTENT_MEME. Same shape as Pic; memes come
+	// from iFunny's legacy "Meme" creator.
+	Meme *PicPayload `json:"mem,omitempty"`
+	// Populated when Type == CONTENT_VIDEO_CLIP.
+	VideoClip *VideoClipPayload `json:"video_clip,omitempty"`
+	// Populated when Type == CONTENT_VIDEO.
+	Video *VideoPayload `json:"video,omitempty"`
+	// Populated when Type == CONTENT_VINE.
+	Vine *VinePayload `json:"vine,omitempty"`
+	// Populated when Type == CONTENT_COUB.
+	Coub *CoubPayload `json:"coub,omitempty"`
+	// Populated when Type is CONTENT_GIF or CONTENT_GIF_CAPTION. The API
+	// uses the same "gif" key for both; CaptionText is only meaningful
+	// (non-empty) for CONTENT_GIF_CAPTION.
+	Gif *GifPayload `json:"gif,omitempty"`
+	// Populated when Type == CONTENT_CAPTION.
+	Caption *CaptionPayload `json:"caption,omitempty"`
+	// Populated when Type == CONTENT_APP.
+	App *AppPayload `json:"app,omitempty"`
+}
 
-	// type = video_clip
-	VideoClip struct {
-		ScreenURL  string `json:"screen_url"`
-		SourceType string `json:"source_type"`
-		Bytes      int    `json:"bytes"`
-		Duration   int    `json:"duration"`
-	} `json:"video_clip,omitempty"`
+// Payload returns the kind-specific data for c as a Payload, chosen by
+// c.Type. It returns nil for kinds with no documented payload (CONTENT_OLD,
+// CONTENT_DEM, CONTENT_SPECIAL) or if the expected field wasn't populated.
+//
+// Callers that don't care which exact kind they're holding can type-assert
+// the result against the narrower capability interfaces below (Media,
+// Preview, Sized, Captioned) instead of switching over every ContentKind:
+//
+//	if media, ok := content.Payload().(ifunny.Media); ok {
+//		fmt.Println(media.URL())
+//	}
+func (c *Content) Payload() Payload {
+	switch c.Type {
+	case CONTENT_PIC:
+		return payloadOrNil(c.Pic)
+	case CONTENT_COMICS:
+		return payloadOrNil(c.Comics)
+	case CONTENT_MEME:
+		return payloadOrNil(c.Meme)
+	case CONTENT_VIDEO_CLIP:
+		return payloadOrNil(c.VideoClip)
+	case CONTENT_VIDEO:
+		return payloadOrNil(c.Video)
+	case CONTENT_VINE:
+		return payloadOrNil(c.Vine)
+	case CONTENT_COUB:
+		return payloadOrNil(c.Coub)
+	case CONTENT_GIF, CONTENT_GIF_CAPTION:
+		return payloadOrNil(c.Gif)
+	case CONTENT_CAPTION:
+		return payloadOrNil(c.Caption)
+	case CONTENT_APP:
+		return payloadOrNil(c.App)
+	default:
+		return nil
+	}
+}
+
+// payloadOrNil returns p as a Payload, or a true nil interface (rather than
+// a non-nil interface wrapping a nil pointer) when p itself is nil. The
+// comparison happens before p is boxed into the Payload interface, so it
+// sidesteps the usual "non-nil interface holding a nil pointer" trap.
+func payloadOrNil[T interface {
+	Payload
+	comparable
+}](p T) Payload {
+	var zero T
+	if p == zero {
+		return nil
+	}
+	return p
 }
 
 // Cursor holds pagination metadata for paginated API responses. It includes opaque

--- a/content_payload.go
+++ b/content_payload.go
@@ -1,0 +1,153 @@
+package ifunny
+
+// Payload is implemented by every kind-specific payload struct embedded in
+// Content (Content.Pic, Content.VideoClip, Content.Gif, ...). On its own it
+// says nothing about what the payload contains — it exists so Content.Payload
+// can hand back whatever is populated as a single value, and so the method
+// set is sealed to the payload types declared in this package.
+//
+// The useful information comes from type-asserting a Payload against the
+// narrower capability interfaces below. Not every kind implements every
+// capability: what a "pic" and a "video_clip" have in common isn't a shared
+// set of fields, it's that both answer a subset of the same questions
+// ("where's the preview image?", "where's the playable media?", "how big is
+// it?"). Modeling that as a handful of single-method interfaces (in the
+// spirit of io.Reader/io.Writer) lets callers ask only the question they
+// care about instead of switching over every ContentKind.
+type Payload interface {
+	// sealed prevents types outside this package from satisfying Payload.
+	sealed()
+}
+
+// Media is implemented by payloads whose data is a single URL pointing at
+// the actual media that was posted: images (Pic, Comics, Meme), the
+// original source of an imported video (Video), gifs (Gif — covers both
+// CONTENT_GIF and CONTENT_GIF_CAPTION), and third-party embeds (App).
+// VideoClip, Vine, and Coub don't implement Media: the API only gives us a
+// still preview for them (see Preview), not a direct media URL.
+type Media interface {
+	Payload
+	URL() string
+}
+
+// Preview is implemented by payloads that carry a still-frame preview image
+// distinct from their own media: VideoClip, Vine, Coub, and Gif.
+type Preview interface {
+	Payload
+	PreviewURL() string
+}
+
+// Sized is implemented by payloads that report their own encoded size in
+// bytes: VideoClip, Vine, Coub, and Gif. Kinds without a byte count in the
+// API response (Pic-family, Caption, App) don't implement it.
+type Sized interface {
+	Payload
+	Size() int
+}
+
+// Captioned is implemented by payloads that carry caption text composited
+// over other content: Caption, and Gif (meaningful only when the owning
+// Content's Type is CONTENT_GIF_CAPTION; empty for plain gifs).
+type Captioned interface {
+	Payload
+	Caption() string
+}
+
+// PicPayload is the payload for CONTENT_PIC, CONTENT_COMICS, and
+// CONTENT_MEME: a single webp image. The three kinds differ only in which
+// in-app tool produced the image, not in shape.
+type PicPayload struct {
+	WebpURL string `json:"webp_url"`
+}
+
+func (*PicPayload) sealed()       {}
+func (p *PicPayload) URL() string { return p.WebpURL }
+
+// VideoClipPayload is the payload for CONTENT_VIDEO_CLIP, the most common
+// video kind.
+type VideoClipPayload struct {
+	ScreenURL  string `json:"screen_url"` // JPEG preview frame
+	SourceType string `json:"source_type"`
+	LogoURL    string `json:"logo_url,omitempty"` // source logo, present when SourceType != "user"
+	Bytes      int    `json:"bytes"`
+	Duration   int    `json:"duration"` // seconds
+}
+
+func (*VideoClipPayload) sealed()              {}
+func (p *VideoClipPayload) PreviewURL() string { return p.ScreenURL }
+func (p *VideoClipPayload) Size() int          { return p.Bytes }
+
+// VideoPayload is the payload for CONTENT_VIDEO: a video imported from an
+// external URL (e.g. YouTube), as opposed to one recorded/uploaded directly
+// (CONTENT_VIDEO_CLIP).
+type VideoPayload struct {
+	SourceURL string `json:"url"`
+	Duration  int    `json:"duration"` // seconds
+	Length    int    `json:"length"`   // seconds; observed equal to Duration
+}
+
+func (*VideoPayload) sealed()       {}
+func (p *VideoPayload) URL() string { return p.SourceURL }
+
+// VinePayload is the payload for CONTENT_VINE: a legacy import from the
+// defunct Vine app.
+type VinePayload struct {
+	ScreenURL string `json:"screen_url"`
+	Bytes     int    `json:"bytes"`
+}
+
+func (*VinePayload) sealed()              {}
+func (p *VinePayload) PreviewURL() string { return p.ScreenURL }
+func (p *VinePayload) Size() int          { return p.Bytes }
+
+// CoubPayload is the payload for CONTENT_COUB: a video meme imported from
+// coub.com.
+type CoubPayload struct {
+	ScreenURL    string `json:"screen_url"`
+	Bytes        int    `json:"bytes"`
+	TrackbackURL string `json:"trackback_url"` // original Coub source
+	Duration     int    `json:"duration"`      // seconds
+}
+
+func (*CoubPayload) sealed()              {}
+func (p *CoubPayload) PreviewURL() string { return p.ScreenURL }
+func (p *CoubPayload) Size() int          { return p.Bytes }
+
+// GifPayload is the payload for both CONTENT_GIF and CONTENT_GIF_CAPTION;
+// the API uses the same "gif" JSON key for either kind. CaptionText is only
+// populated for CONTENT_GIF_CAPTION.
+type GifPayload struct {
+	ScreenURL   string `json:"screen_url"` // JPEG preview frame
+	Bytes       int    `json:"bytes"`
+	Mp4URL      string `json:"mp4_url"`
+	Mp4Bytes    int    `json:"mp4_bytes"`
+	WebmURL     string `json:"webm_url,omitempty"`
+	WebmBytes   int    `json:"webm_bytes"`
+	CaptionText string `json:"caption_text,omitempty"` // only set for CONTENT_GIF_CAPTION
+}
+
+func (*GifPayload) sealed()              {}
+func (p *GifPayload) URL() string        { return p.Mp4URL }
+func (p *GifPayload) PreviewURL() string { return p.ScreenURL }
+func (p *GifPayload) Size() int          { return p.Bytes }
+func (p *GifPayload) Caption() string    { return p.CaptionText }
+
+// CaptionPayload is the payload for CONTENT_CAPTION: a custom caption
+// composited onto an image meme. Unlike Pic, it carries no media URL of its
+// own — the underlying image lives on the Content itself.
+type CaptionPayload struct {
+	CaptionText string `json:"caption_text"`
+}
+
+func (*CaptionPayload) sealed()           {}
+func (p *CaptionPayload) Caption() string { return p.CaptionText }
+
+// AppPayload is the payload for CONTENT_APP: an interactive/iframe card.
+// Deprecated by iFunny; kept for decoding historical content.
+type AppPayload struct {
+	SourceURL       string `json:"url"`
+	IsScrollAllowed bool   `json:"is_scroll_allowed"`
+}
+
+func (*AppPayload) sealed()       {}
+func (p *AppPayload) URL() string { return p.SourceURL }

--- a/content_payload.go
+++ b/content_payload.go
@@ -53,19 +53,19 @@ type Captioned interface {
 	Caption() string
 }
 
-// PicPayload is the payload for CONTENT_PIC, CONTENT_COMICS, and
+// PayloadPic is the payload for CONTENT_PIC, CONTENT_COMICS, and
 // CONTENT_MEME: a single webp image. The three kinds differ only in which
 // in-app tool produced the image, not in shape.
-type PicPayload struct {
+type PayloadPic struct {
 	WebpURL string `json:"webp_url"`
 }
 
-func (*PicPayload) sealed()       {}
-func (p *PicPayload) URL() string { return p.WebpURL }
+func (*PayloadPic) sealed()       {}
+func (p *PayloadPic) URL() string { return p.WebpURL }
 
-// VideoClipPayload is the payload for CONTENT_VIDEO_CLIP, the most common
+// PayloadVideoClip is the payload for CONTENT_VIDEO_CLIP, the most common
 // video kind.
-type VideoClipPayload struct {
+type PayloadVideoClip struct {
 	ScreenURL  string `json:"screen_url"` // JPEG preview frame
 	SourceType string `json:"source_type"`
 	LogoURL    string `json:"logo_url,omitempty"` // source logo, present when SourceType != "user"
@@ -73,50 +73,50 @@ type VideoClipPayload struct {
 	Duration   int    `json:"duration"` // seconds
 }
 
-func (*VideoClipPayload) sealed()              {}
-func (p *VideoClipPayload) PreviewURL() string { return p.ScreenURL }
-func (p *VideoClipPayload) Size() int          { return p.Bytes }
+func (*PayloadVideoClip) sealed()              {}
+func (p *PayloadVideoClip) PreviewURL() string { return p.ScreenURL }
+func (p *PayloadVideoClip) Size() int          { return p.Bytes }
 
-// VideoPayload is the payload for CONTENT_VIDEO: a video imported from an
+// PayloadVideo is the payload for CONTENT_VIDEO: a video imported from an
 // external URL (e.g. YouTube), as opposed to one recorded/uploaded directly
 // (CONTENT_VIDEO_CLIP).
-type VideoPayload struct {
+type PayloadVideo struct {
 	SourceURL string `json:"url"`
 	Duration  int    `json:"duration"` // seconds
 	Length    int    `json:"length"`   // seconds; observed equal to Duration
 }
 
-func (*VideoPayload) sealed()       {}
-func (p *VideoPayload) URL() string { return p.SourceURL }
+func (*PayloadVideo) sealed()       {}
+func (p *PayloadVideo) URL() string { return p.SourceURL }
 
-// VinePayload is the payload for CONTENT_VINE: a legacy import from the
+// PayloadVine is the payload for CONTENT_VINE: a legacy import from the
 // defunct Vine app.
-type VinePayload struct {
+type PayloadVine struct {
 	ScreenURL string `json:"screen_url"`
 	Bytes     int    `json:"bytes"`
 }
 
-func (*VinePayload) sealed()              {}
-func (p *VinePayload) PreviewURL() string { return p.ScreenURL }
-func (p *VinePayload) Size() int          { return p.Bytes }
+func (*PayloadVine) sealed()              {}
+func (p *PayloadVine) PreviewURL() string { return p.ScreenURL }
+func (p *PayloadVine) Size() int          { return p.Bytes }
 
-// CoubPayload is the payload for CONTENT_COUB: a video meme imported from
+// PayloadCoub is the payload for CONTENT_COUB: a video meme imported from
 // coub.com.
-type CoubPayload struct {
+type PayloadCoub struct {
 	ScreenURL    string `json:"screen_url"`
 	Bytes        int    `json:"bytes"`
 	TrackbackURL string `json:"trackback_url"` // original Coub source
 	Duration     int    `json:"duration"`      // seconds
 }
 
-func (*CoubPayload) sealed()              {}
-func (p *CoubPayload) PreviewURL() string { return p.ScreenURL }
-func (p *CoubPayload) Size() int          { return p.Bytes }
+func (*PayloadCoub) sealed()              {}
+func (p *PayloadCoub) PreviewURL() string { return p.ScreenURL }
+func (p *PayloadCoub) Size() int          { return p.Bytes }
 
-// GifPayload is the payload for both CONTENT_GIF and CONTENT_GIF_CAPTION;
+// PayloadGif is the payload for both CONTENT_GIF and CONTENT_GIF_CAPTION;
 // the API uses the same "gif" JSON key for either kind. CaptionText is only
 // populated for CONTENT_GIF_CAPTION.
-type GifPayload struct {
+type PayloadGif struct {
 	ScreenURL   string `json:"screen_url"` // JPEG preview frame
 	Bytes       int    `json:"bytes"`
 	Mp4URL      string `json:"mp4_url"`
@@ -126,28 +126,28 @@ type GifPayload struct {
 	CaptionText string `json:"caption_text,omitempty"` // only set for CONTENT_GIF_CAPTION
 }
 
-func (*GifPayload) sealed()              {}
-func (p *GifPayload) URL() string        { return p.Mp4URL }
-func (p *GifPayload) PreviewURL() string { return p.ScreenURL }
-func (p *GifPayload) Size() int          { return p.Bytes }
-func (p *GifPayload) Caption() string    { return p.CaptionText }
+func (*PayloadGif) sealed()              {}
+func (p *PayloadGif) URL() string        { return p.Mp4URL }
+func (p *PayloadGif) PreviewURL() string { return p.ScreenURL }
+func (p *PayloadGif) Size() int          { return p.Bytes }
+func (p *PayloadGif) Caption() string    { return p.CaptionText }
 
-// CaptionPayload is the payload for CONTENT_CAPTION: a custom caption
+// PayloadCaption is the payload for CONTENT_CAPTION: a custom caption
 // composited onto an image meme. Unlike Pic, it carries no media URL of its
 // own — the underlying image lives on the Content itself.
-type CaptionPayload struct {
+type PayloadCaption struct {
 	CaptionText string `json:"caption_text"`
 }
 
-func (*CaptionPayload) sealed()           {}
-func (p *CaptionPayload) Caption() string { return p.CaptionText }
+func (*PayloadCaption) sealed()           {}
+func (p *PayloadCaption) Caption() string { return p.CaptionText }
 
-// AppPayload is the payload for CONTENT_APP: an interactive/iframe card.
+// PayloadApp is the payload for CONTENT_APP: an interactive/iframe card.
 // Deprecated by iFunny; kept for decoding historical content.
-type AppPayload struct {
+type PayloadApp struct {
 	SourceURL       string `json:"url"`
 	IsScrollAllowed bool   `json:"is_scroll_allowed"`
 }
 
-func (*AppPayload) sealed()       {}
-func (p *AppPayload) URL() string { return p.SourceURL }
+func (*PayloadApp) sealed()       {}
+func (p *PayloadApp) URL() string { return p.SourceURL }

--- a/content_payload_test.go
+++ b/content_payload_test.go
@@ -1,0 +1,119 @@
+package ifunny
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestContent_Payload_DecodesEveryKnownKind decodes a minimal JSON payload
+// for every ContentKind with a documented shape and confirms Content.Payload
+// returns the matching populated struct.
+func TestContent_Payload_DecodesEveryKnownKind(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want Payload
+	}{
+		{"pic", `{"type":"pic","pic":{"webp_url":"https://x/pic.webp"}}`,
+			&PicPayload{WebpURL: "https://x/pic.webp"}},
+		{"comics", `{"type":"comics","comics":{"webp_url":"https://x/comic.webp"}}`,
+			&PicPayload{WebpURL: "https://x/comic.webp"}},
+		{"mem", `{"type":"mem","mem":{"webp_url":"https://x/meme.webp"}}`,
+			&PicPayload{WebpURL: "https://x/meme.webp"}},
+		{"video_clip", `{"type":"video_clip","video_clip":{"screen_url":"https://x/s.jpg","bytes":10,"source_type":"user","duration":5}}`,
+			&VideoClipPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, SourceType: "user", Duration: 5}},
+		{"video", `{"type":"video","video":{"url":"https://x/v.mp4","duration":5,"length":5}}`,
+			&VideoPayload{SourceURL: "https://x/v.mp4", Duration: 5, Length: 5}},
+		{"vine", `{"type":"vine","vine":{"screen_url":"https://x/s.jpg","bytes":10}}`,
+			&VinePayload{ScreenURL: "https://x/s.jpg", Bytes: 10}},
+		{"coub", `{"type":"coub","coub":{"screen_url":"https://x/s.jpg","bytes":10,"trackback_url":"https://coub.com/x","duration":5}}`,
+			&CoubPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, TrackbackURL: "https://coub.com/x", Duration: 5}},
+		{"gif", `{"type":"gif","gif":{"screen_url":"https://x/s.jpg","bytes":10,"mp4_url":"https://x/g.mp4","mp4_bytes":20}}`,
+			&GifPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20}},
+		{"gif_caption", `{"type":"gif_caption","gif":{"screen_url":"https://x/s.jpg","bytes":10,"mp4_url":"https://x/g.mp4","mp4_bytes":20,"caption_text":"lol"}}`,
+			&GifPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20, CaptionText: "lol"}},
+		{"caption", `{"type":"caption","caption":{"caption_text":"lol"}}`,
+			&CaptionPayload{CaptionText: "lol"}},
+		{"app", `{"type":"app","app":{"url":"https://x/app","is_scroll_allowed":true}}`,
+			&AppPayload{SourceURL: "https://x/app", IsScrollAllowed: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Content
+			if err := json.Unmarshal([]byte(tc.json), &c); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			got := c.Payload()
+			if got == nil {
+				t.Fatal("Payload() = nil, want a populated payload")
+			}
+			if gotJSON, wantJSON := mustJSON(t, got), mustJSON(t, tc.want); gotJSON != wantJSON {
+				t.Errorf("Payload() = %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// TestContent_Payload_UndocumentedKinds confirms that CONTENT_OLD,
+// CONTENT_DEM, and CONTENT_SPECIAL — which have no documented payload shape
+// — decode without error and yield a nil Payload rather than panicking or
+// fabricating data.
+func TestContent_Payload_UndocumentedKinds(t *testing.T) {
+	for _, kind := range []ContentKind{CONTENT_OLD, CONTENT_DEM, CONTENT_SPECIAL} {
+		var c Content
+		body := `{"type":"` + string(kind) + `"}`
+		if err := json.Unmarshal([]byte(body), &c); err != nil {
+			t.Fatalf("Unmarshal(%s): %v", kind, err)
+		}
+		if p := c.Payload(); p != nil {
+			t.Errorf("Payload() for %s = %#v, want nil", kind, p)
+		}
+	}
+}
+
+// TestPayload_CapabilityInterfaces spot-checks which capability interfaces
+// (Media, Preview, Sized, Captioned) each payload kind is expected to
+// implement, since that's the whole point of splitting them out instead of
+// one bloated interface.
+func TestPayload_CapabilityInterfaces(t *testing.T) {
+	pic := &PicPayload{WebpURL: "https://x/p.webp"}
+	assertImplements[Media](t, "PicPayload", pic)
+
+	clip := &VideoClipPayload{ScreenURL: "https://x/s.jpg"}
+	assertImplements[Preview](t, "VideoClipPayload", clip)
+	assertImplements[Sized](t, "VideoClipPayload", clip)
+
+	video := &VideoPayload{SourceURL: "https://x/v.mp4"}
+	assertImplements[Media](t, "VideoPayload", video)
+
+	gif := &GifPayload{Mp4URL: "https://x/g.mp4", ScreenURL: "https://x/s.jpg", CaptionText: "lol"}
+	assertImplements[Media](t, "GifPayload", gif)
+	assertImplements[Preview](t, "GifPayload", gif)
+	assertImplements[Sized](t, "GifPayload", gif)
+	assertImplements[Captioned](t, "GifPayload", gif)
+
+	caption := &CaptionPayload{CaptionText: "lol"}
+	assertImplements[Captioned](t, "CaptionPayload", caption)
+
+	app := &AppPayload{SourceURL: "https://x/app"}
+	assertImplements[Media](t, "AppPayload", app)
+}
+
+func assertImplements[I any](t *testing.T, name string, p Payload) {
+	t.Helper()
+	if _, ok := p.(I); !ok {
+		var zero I
+		t.Errorf("%s does not implement %T", name, zero)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return string(b)
+}

--- a/content_payload_test.go
+++ b/content_payload_test.go
@@ -15,27 +15,27 @@ func TestContent_Payload_DecodesEveryKnownKind(t *testing.T) {
 		want Payload
 	}{
 		{"pic", `{"type":"pic","pic":{"webp_url":"https://x/pic.webp"}}`,
-			&PicPayload{WebpURL: "https://x/pic.webp"}},
+			&PayloadPic{WebpURL: "https://x/pic.webp"}},
 		{"comics", `{"type":"comics","comics":{"webp_url":"https://x/comic.webp"}}`,
-			&PicPayload{WebpURL: "https://x/comic.webp"}},
+			&PayloadPic{WebpURL: "https://x/comic.webp"}},
 		{"mem", `{"type":"mem","mem":{"webp_url":"https://x/meme.webp"}}`,
-			&PicPayload{WebpURL: "https://x/meme.webp"}},
+			&PayloadPic{WebpURL: "https://x/meme.webp"}},
 		{"video_clip", `{"type":"video_clip","video_clip":{"screen_url":"https://x/s.jpg","bytes":10,"source_type":"user","duration":5}}`,
-			&VideoClipPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, SourceType: "user", Duration: 5}},
+			&PayloadVideoClip{ScreenURL: "https://x/s.jpg", Bytes: 10, SourceType: "user", Duration: 5}},
 		{"video", `{"type":"video","video":{"url":"https://x/v.mp4","duration":5,"length":5}}`,
-			&VideoPayload{SourceURL: "https://x/v.mp4", Duration: 5, Length: 5}},
+			&PayloadVideo{SourceURL: "https://x/v.mp4", Duration: 5, Length: 5}},
 		{"vine", `{"type":"vine","vine":{"screen_url":"https://x/s.jpg","bytes":10}}`,
-			&VinePayload{ScreenURL: "https://x/s.jpg", Bytes: 10}},
+			&PayloadVine{ScreenURL: "https://x/s.jpg", Bytes: 10}},
 		{"coub", `{"type":"coub","coub":{"screen_url":"https://x/s.jpg","bytes":10,"trackback_url":"https://coub.com/x","duration":5}}`,
-			&CoubPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, TrackbackURL: "https://coub.com/x", Duration: 5}},
+			&PayloadCoub{ScreenURL: "https://x/s.jpg", Bytes: 10, TrackbackURL: "https://coub.com/x", Duration: 5}},
 		{"gif", `{"type":"gif","gif":{"screen_url":"https://x/s.jpg","bytes":10,"mp4_url":"https://x/g.mp4","mp4_bytes":20}}`,
-			&GifPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20}},
+			&PayloadGif{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20}},
 		{"gif_caption", `{"type":"gif_caption","gif":{"screen_url":"https://x/s.jpg","bytes":10,"mp4_url":"https://x/g.mp4","mp4_bytes":20,"caption_text":"lol"}}`,
-			&GifPayload{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20, CaptionText: "lol"}},
+			&PayloadGif{ScreenURL: "https://x/s.jpg", Bytes: 10, Mp4URL: "https://x/g.mp4", Mp4Bytes: 20, CaptionText: "lol"}},
 		{"caption", `{"type":"caption","caption":{"caption_text":"lol"}}`,
-			&CaptionPayload{CaptionText: "lol"}},
+			&PayloadCaption{CaptionText: "lol"}},
 		{"app", `{"type":"app","app":{"url":"https://x/app","is_scroll_allowed":true}}`,
-			&AppPayload{SourceURL: "https://x/app", IsScrollAllowed: true}},
+			&PayloadApp{SourceURL: "https://x/app", IsScrollAllowed: true}},
 	}
 
 	for _, tc := range cases {
@@ -78,27 +78,27 @@ func TestContent_Payload_UndocumentedKinds(t *testing.T) {
 // implement, since that's the whole point of splitting them out instead of
 // one bloated interface.
 func TestPayload_CapabilityInterfaces(t *testing.T) {
-	pic := &PicPayload{WebpURL: "https://x/p.webp"}
-	assertImplements[Media](t, "PicPayload", pic)
+	pic := &PayloadPic{WebpURL: "https://x/p.webp"}
+	assertImplements[Media](t, "PayloadPic", pic)
 
-	clip := &VideoClipPayload{ScreenURL: "https://x/s.jpg"}
-	assertImplements[Preview](t, "VideoClipPayload", clip)
-	assertImplements[Sized](t, "VideoClipPayload", clip)
+	clip := &PayloadVideoClip{ScreenURL: "https://x/s.jpg"}
+	assertImplements[Preview](t, "PayloadVideoClip", clip)
+	assertImplements[Sized](t, "PayloadVideoClip", clip)
 
-	video := &VideoPayload{SourceURL: "https://x/v.mp4"}
-	assertImplements[Media](t, "VideoPayload", video)
+	video := &PayloadVideo{SourceURL: "https://x/v.mp4"}
+	assertImplements[Media](t, "PayloadVideo", video)
 
-	gif := &GifPayload{Mp4URL: "https://x/g.mp4", ScreenURL: "https://x/s.jpg", CaptionText: "lol"}
-	assertImplements[Media](t, "GifPayload", gif)
-	assertImplements[Preview](t, "GifPayload", gif)
-	assertImplements[Sized](t, "GifPayload", gif)
-	assertImplements[Captioned](t, "GifPayload", gif)
+	gif := &PayloadGif{Mp4URL: "https://x/g.mp4", ScreenURL: "https://x/s.jpg", CaptionText: "lol"}
+	assertImplements[Media](t, "PayloadGif", gif)
+	assertImplements[Preview](t, "PayloadGif", gif)
+	assertImplements[Sized](t, "PayloadGif", gif)
+	assertImplements[Captioned](t, "PayloadGif", gif)
 
-	caption := &CaptionPayload{CaptionText: "lol"}
-	assertImplements[Captioned](t, "CaptionPayload", caption)
+	caption := &PayloadCaption{CaptionText: "lol"}
+	assertImplements[Captioned](t, "PayloadCaption", caption)
 
-	app := &AppPayload{SourceURL: "https://x/app"}
-	assertImplements[Media](t, "AppPayload", app)
+	app := &PayloadApp{SourceURL: "https://x/app"}
+	assertImplements[Media](t, "PayloadApp", app)
 }
 
 func assertImplements[I any](t *testing.T, name string, p Payload) {


### PR DESCRIPTION
## Summary
- Add the 11 missing `ContentKind` values (`video`, `vine`, `coub`, `gif`, `gif_caption`, `caption`, `mem`, `app`, `old`, `dem`, `special`) alongside the existing `pic`/`video_clip`/`comics`, backed by a new `ContentKind` string type instead of untyped consts (verified against `MakeShiftArtist/ifunny-api-types`, which has the fields for each kind).
- Add a payload struct per kind (`PicPayload`, `VideoClipPayload`, `VideoPayload`, `VinePayload`, `CoubPayload`, `GifPayload`, `CaptionPayload`, `AppPayload`), decoded onto `Content` based on `Type`, with `Content.Payload()` returning whichever one is populated.
- Rather than one interface trying to cover every kind's fields (which don't actually overlap), split the questions callers ask about "what was posted" into small capability interfaces: `Media` (direct URL), `Preview` (thumbnail), `Sized` (byte count), `Captioned` (caption text) — each payload implements only what the API actually supports for that kind.

Closes #6.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New `content_payload_test.go`: decode coverage for all 12 documented kinds, nil-payload behavior for the 3 undocumented kinds (`old`/`dem`/`special`), and capability-interface assertions per kind