### PR TITLE
Envelope-typed generic Iter for all paginated endpoints

### DIFF
--- a/chat-channel.go
+++ b/chat-channel.go
@@ -125,22 +125,20 @@ func (client *Client) GetChannels(ctx context.Context, desc compose.Request) ([]
 	return output.Data.Channels, err
 }
 
-// GetChannelsPage fetches a single page of chat channels given a composed request.
-// It is used internally by channel iteration methods and exported for advanced use cases.
-func (client *Client) GetChannelsPage(ctx context.Context, desc compose.Request) (*Page[ChatChannel], error) {
-	output := new(struct {
-		Data struct {
-			Channels Page[ChatChannel] `json:"channels"`
-		} `json:"data"`
-	})
-	err := client.RequestJSON(ctx, desc, output)
-	return &output.Data.Channels, err
+// ChannelsEnvelope is the response envelope for a chat-channel feed: the page
+// lives at data.channels. Hand it to [FetchPage]/[Iter] as E.
+type ChannelsEnvelope struct {
+	Data struct {
+		Channels Page[ChatChannel] `json:"channels"`
+	} `json:"data"`
 }
+
+func (e ChannelsEnvelope) page() Page[ChatChannel] { return e.Data.Channels }
 
 // IterChannelsQuery returns a channel that yields chat channels matching a search query.
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterChannelsQuery(ctx context.Context, query string) <-chan Result[*ChatChannel] {
-	return iterFrom(ctx, client, compose.Chats(query), client.GetChannelsPage)
+	return Iter[ChannelsEnvelope](ctx, client, compose.Chats(query))
 }
 
 // IterChannelsTrending returns a channel that yields the current trending chat
@@ -155,7 +153,7 @@ func (client *Client) IterChannelsTrending(ctx context.Context) <-chan Result[*C
 		case data <- r:
 			return true
 		case <-ctx.Done():
-			// Best-effort delivery of the cancellation, matching iterFrom.
+			// Best-effort delivery of the cancellation, matching Iter.
 			select {
 			case data <- Result[*ChatChannel]{Err: ctx.Err()}:
 			default:

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -30,15 +30,6 @@ type ChatChannel struct {
 	} `json:"user"`
 }
 
-// ChatChannelPage wraps a paginated response of chat channels and a count.
-type ChatChannelPage struct {
-	Channels struct {
-		Items  []*ChatChannel `json:"items"`
-		Paging Cursor         `json:"paging"`
-	} `json:"channels"`
-	Num int `json:"num"`
-}
-
 func (chat *Chat) handleChannelsRaw(handle func(eventType int, channel *ChatChannel) error) EventHandler {
 	return func(eventType int, kwargs map[string]any) error {
 		log := chat.client.log.WithFields(logrus.Fields{"event_type": eventType, "kwargs": kwargs})

--- a/chat-channel.go
+++ b/chat-channel.go
@@ -144,7 +144,8 @@ func (client *Client) IterChannelsTrending(ctx context.Context) <-chan Result[*C
 		case data <- r:
 			return true
 		case <-ctx.Done():
-			// Best-effort delivery of the cancellation, matching Iter.
+			// Best-effort delivery of the cancellation so a still-listening
+			// consumer can tell cancellation from exhaustion.
 			select {
 			case data <- Result[*ChatChannel]{Err: ctx.Err()}:
 			default:

--- a/chat-message.go
+++ b/chat-message.go
@@ -119,7 +119,8 @@ func (chat *Chat) IterMessages(ctx context.Context, desc turnpike.Call) <-chan R
 		case data <- r:
 			return true
 		case <-ctx.Done():
-			// Best-effort delivery of the cancellation, matching Iter.
+			// Best-effort delivery of the cancellation so a still-listening
+			// consumer can tell cancellation from exhaustion.
 			select {
 			case data <- Result[*ChatEvent]{Err: ctx.Err()}:
 			default:

--- a/chat-message.go
+++ b/chat-message.go
@@ -119,7 +119,7 @@ func (chat *Chat) IterMessages(ctx context.Context, desc turnpike.Call) <-chan R
 		case data <- r:
 			return true
 		case <-ctx.Done():
-			// Best-effort delivery of the cancellation, matching iterFrom.
+			// Best-effort delivery of the cancellation, matching Iter.
 			select {
 			case data <- Result[*ChatEvent]{Err: ctx.Err()}:
 			default:

--- a/comment.go
+++ b/comment.go
@@ -64,10 +64,67 @@ type CommentsEnvelope struct {
 
 func (e CommentsEnvelope) page() Page[Comment] { return e.Data.Comments }
 
-// IterComments returns a channel that yields top-level comments on content (identified by ID).
-// The iterator automatically fetches new pages as needed.
-func (client *Client) IterComments(ctx context.Context, id string) <-chan Result[*Comment] {
+// IterCommentsRoots returns a channel that yields only the top-level (root)
+// comments on content (identified by ID); replies are not descended into. The
+// iterator automatically fetches new pages as needed. Use [Client.IterCommentsForest]
+// to walk roots and all of their nested replies.
+func (client *Client) IterCommentsRoots(ctx context.Context, id string) <-chan Result[*Comment] {
 	return Iter[CommentsEnvelope](ctx, client, compose.Comments(id))
+}
+
+// IterCommentsForest returns a channel that yields every comment on content
+// (identified by ID) in depth-first order: each root comment is emitted, then
+// its replies recursively (a reply and its own replies before the next sibling),
+// then the next root. It stitches [Client.IterCommentsRoots] and
+// [Client.IterReplies] together, descending into a comment only when its
+// reported reply count (Num.Replies) is non-zero to avoid empty reply requests
+// on leaves.
+//
+// Errors and cancellation follow the same contract as the other iterators (see
+// [Result]): a fetch failure anywhere in the walk is delivered as a final Result
+// with Err set before the channel closes, and cancelling ctx stops the walk.
+func (client *Client) IterCommentsForest(ctx context.Context, id string) <-chan Result[*Comment] {
+	data := make(chan Result[*Comment])
+
+	send := func(r Result[*Comment]) bool {
+		select {
+		case data <- r:
+			return true
+		case <-ctx.Done():
+			select {
+			case data <- Result[*Comment]{Err: ctx.Err()}:
+			default:
+			}
+			return false
+		}
+	}
+
+	// walk emits every comment from src, descending into the replies of any
+	// comment that reports having some. It returns false as soon as delivery
+	// fails (ctx cancelled) or a source yields an error, so callers unwind the
+	// whole traversal.
+	var walk func(src <-chan Result[*Comment]) bool
+	walk = func(src <-chan Result[*Comment]) bool {
+		for r := range src {
+			if !send(r) {
+				return false
+			}
+			if r.Err != nil {
+				return false
+			}
+			if r.V.Num.Replies > 0 && !walk(client.IterReplies(ctx, id, r.V.ID)) {
+				return false
+			}
+		}
+		return true
+	}
+
+	go func() {
+		defer close(data)
+		walk(client.IterCommentsRoots(ctx, id))
+	}()
+
+	return data
 }
 
 // RepliesEnvelope is the response envelope for a reply feed: the page lives at

--- a/comment.go
+++ b/comment.go
@@ -54,40 +54,35 @@ type Comment struct {
 	} `json:"content_thumbs"`
 }
 
-// GetCommentPage fetches a single page of comments given a composed request.
-// It is used internally by comment iteration methods and exported for advanced use cases.
-func (client *Client) GetCommentPage(ctx context.Context, request compose.Request) (*Page[Comment], error) {
-	content := new(struct {
-		Data struct {
-			Comments Page[Comment] `json:"comments"`
-		}
-	})
-
-	err := client.RequestJSON(ctx, request, content)
-	return &content.Data.Comments, err
+// CommentsEnvelope is the response envelope for a comment feed: the page lives
+// at data.comments. Hand it to [FetchPage]/[Iter] as E.
+type CommentsEnvelope struct {
+	Data struct {
+		Comments Page[Comment] `json:"comments"`
+	} `json:"data"`
 }
+
+func (e CommentsEnvelope) page() Page[Comment] { return e.Data.Comments }
 
 // IterComments returns a channel that yields top-level comments on content (identified by ID).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterComments(ctx context.Context, id string) <-chan Result[*Comment] {
-	return iterFrom(ctx, client, compose.Comments(id), client.GetCommentPage)
+	return Iter[CommentsEnvelope](ctx, client, compose.Comments(id))
 }
 
-// GetRepliesPage fetches a single page of replies to a comment given a composed request.
-// It is used internally by reply iteration methods and exported for advanced use cases.
-func (client *Client) GetRepliesPage(ctx context.Context, request compose.Request) (*Page[Comment], error) {
-	content := new(struct {
-		Data struct {
-			Replies Page[Comment] `json:"replies"`
-		} `json:"data"`
-	})
-
-	err := client.RequestJSON(ctx, request, content)
-	return &content.Data.Replies, err
+// RepliesEnvelope is the response envelope for a reply feed: the page lives at
+// data.replies. It carries [Comment]s like [CommentsEnvelope], but this endpoint
+// nests them under a different key. Hand it to [FetchPage]/[Iter] as E.
+type RepliesEnvelope struct {
+	Data struct {
+		Replies Page[Comment] `json:"replies"`
+	} `json:"data"`
 }
+
+func (e RepliesEnvelope) page() Page[Comment] { return e.Data.Replies }
 
 // IterReplies returns a channel that yields replies to a specific comment (identified by cid on content id).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterReplies(ctx context.Context, cid, id string) <-chan Result[*Comment] {
-	return iterFrom(ctx, client, compose.Replies(cid, id), client.GetRepliesPage)
+	return Iter[RepliesEnvelope](ctx, client, compose.Replies(cid, id))
 }

--- a/comment.go
+++ b/comment.go
@@ -64,18 +64,18 @@ type CommentsEnvelope struct {
 
 func (e CommentsEnvelope) page() Page[Comment] { return e.Data.Comments }
 
-// IterCommentsRoots returns a channel that yields only the top-level (root)
-// comments on content (identified by ID); replies are not descended into. The
-// iterator automatically fetches new pages as needed. Use [Client.IterCommentsForest]
-// to walk roots and all of their nested replies.
-func (client *Client) IterCommentsRoots(ctx context.Context, id string) <-chan Result[*Comment] {
+// IterComments returns a channel that yields only the top-level (root) comments
+// on content (identified by ID); replies are not descended into. The iterator
+// automatically fetches new pages as needed. Use [Client.IterCommentsForest] to
+// walk roots and all of their nested replies.
+func (client *Client) IterComments(ctx context.Context, id string) <-chan Result[*Comment] {
 	return Iter[CommentsEnvelope](ctx, client, compose.Comments(id))
 }
 
 // IterCommentsForest returns a channel that yields every comment on content
 // (identified by ID) in depth-first order: each root comment is emitted, then
 // its replies recursively (a reply and its own replies before the next sibling),
-// then the next root. It stitches [Client.IterCommentsRoots] and
+// then the next root. It stitches [Client.IterComments] and
 // [Client.IterReplies] together, descending into a comment only when its
 // reported reply count (Num.Replies) is non-zero to avoid empty reply requests
 // on leaves.
@@ -121,7 +121,7 @@ func (client *Client) IterCommentsForest(ctx context.Context, id string) <-chan 
 
 	go func() {
 		defer close(data)
-		walk(client.IterCommentsRoots(ctx, id))
+		walk(client.IterComments(ctx, id))
 	}()
 
 	return data

--- a/comment_test.go
+++ b/comment_test.go
@@ -1,0 +1,66 @@
+package ifunny
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestIterCommentsForest_DepthFirst walks a small comment tree and asserts the
+// forest iterator emits it depth-first — each root, then that root's replies
+// (and their replies) before the next root — stitching the roots endpoint to the
+// per-comment replies endpoint. It also confirms leaves (Num.Replies == 0) are
+// never requested: the mock has no reply page for them and would 404-shaped the
+// decode if they were fetched.
+func TestIterCommentsForest_DepthFirst(t *testing.T) {
+	// tree:
+	//   A (2 replies)
+	//     A1 (1 reply)
+	//       A1a
+	//     A2
+	//   B
+	roots := `{"data":{"comments":{"items":[` +
+		`{"id":"A","num":{"replies":2}},` +
+		`{"id":"B","num":{"replies":0}}` +
+		`],"paging":{"cursors":{},"hasNext":false}}}}`
+	replies := map[string]string{
+		"A": `{"data":{"replies":{"items":[` +
+			`{"id":"A1","num":{"replies":1}},` +
+			`{"id":"A2","num":{"replies":0}}` +
+			`],"paging":{"cursors":{},"hasNext":false}}}}`,
+		"A1": `{"data":{"replies":{"items":[` +
+			`{"id":"A1a","num":{"replies":0}}` +
+			`],"paging":{"cursors":{},"hasNext":false}}}}`,
+	}
+
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/replies") {
+			// .../comments/{commentID}/replies
+			parts := strings.Split(r.URL.Path, "/")
+			commentID := parts[len(parts)-2]
+			body, ok := replies[commentID]
+			if !ok {
+				t.Errorf("unexpected replies fetch for leaf comment %q", commentID)
+			}
+			w.Write([]byte(body))
+			return
+		}
+		w.Write([]byte(roots))
+	})
+
+	var got []string
+	for r := range client.IterCommentsForest(context.Background(), "content1") {
+		if r.Err != nil {
+			t.Fatalf("forest: %v", r.Err)
+		}
+		got = append(got, r.V.ID)
+	}
+
+	want := []string{"A", "A1", "A1a", "A2", "B"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dfs order: got %v, want %v", got, want)
+	}
+}

--- a/content.go
+++ b/content.go
@@ -90,10 +90,8 @@ func (client *Client) GetContent(ctx context.Context, id string) (*Content, erro
 	return &content.Data, err
 }
 
-// FeedEnvelope is the response envelope for content feeds: the page lives at
-// data.content. It is the E to hand [FetchPage] or [Iter] for a /feeds/-style
-// content endpoint (featured, collective, timelines, smiles-on... any feed
-// served in the classic content shape).
+// FeedEnvelope is the response envelope for content feeds (featured, collective,
+// timelines): the page lives at data.content. Hand it to [FetchPage]/[Iter] as E.
 type FeedEnvelope struct {
 	Data struct {
 		Content Page[Content] `json:"content"`

--- a/content.go
+++ b/content.go
@@ -90,18 +90,17 @@ func (client *Client) GetContent(ctx context.Context, id string) (*Content, erro
 	return &content.Data, err
 }
 
-// GetFeedPage fetches a single page of content given a composed request. It is used
-// internally by feed iteration methods and is exported for advanced use cases.
-func (client *Client) GetFeedPage(ctx context.Context, request compose.Request) (*Page[Content], error) {
-	content := new(struct {
-		Data struct {
-			Content Page[Content] `json:"content"`
-		} `json:"data"`
-	})
-
-	err := client.RequestJSON(ctx, request, content)
-	return &content.Data.Content, err
+// FeedEnvelope is the response envelope for content feeds: the page lives at
+// data.content. It is the E to hand [FetchPage] or [Iter] for a /feeds/-style
+// content endpoint (featured, collective, timelines, smiles-on... any feed
+// served in the classic content shape).
+type FeedEnvelope struct {
+	Data struct {
+		Content Page[Content] `json:"content"`
+	} `json:"data"`
 }
+
+func (e FeedEnvelope) page() Page[Content] { return e.Data.Content }
 
 // IterContent returns a channel that yields content from an arbitrary feed
 // descriptor. It is the generic entry point behind IterTimeline/IterCollective/etc.,
@@ -109,7 +108,7 @@ func (client *Client) GetFeedPage(ctx context.Context, request compose.Request) 
 // custom knobs (see [compose.Collective]). The iterator automatically fetches new
 // pages as needed. Cancel ctx to stop.
 func (client *Client) IterContent(ctx context.Context, feed compose.Feed) <-chan Result[*Content] {
-	return iterFrom(ctx, client, feed, client.GetFeedPage)
+	return Iter[FeedEnvelope](ctx, client, feed)
 }
 
 // IterCollective returns a channel that yields content from the collective feed,
@@ -135,11 +134,11 @@ func (client *Client) IterTimelineByNick(ctx context.Context, nick string) <-cha
 // IterSmiles returns a channel that yields users who smiled at the content (identified by ID).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterSmiles(ctx context.Context, id string) <-chan Result[*User] {
-	return iterFrom(ctx, client, compose.Smiles(id), client.GetUsersPage)
+	return Iter[UsersEnvelope](ctx, client, compose.Smiles(id))
 }
 
 // IterRepublishers returns a channel that yields users who republished the content (identified by ID).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterRepublishers(ctx context.Context, id string) <-chan Result[*User] {
-	return iterFrom(ctx, client, compose.Republished(id), client.GetUsersPage)
+	return Iter[UsersEnvelope](ctx, client, compose.Republished(id))
 }

--- a/examples/comment/main.go
+++ b/examples/comment/main.go
@@ -36,7 +36,7 @@ func main() {
 		panic(err)
 	}
 
-	data := client.IterCommentsRoots(ctx, featured.Items[0].ID)
+	data := client.IterComments(ctx, featured.Items[0].ID)
 	for i := 0; i < 60; i++ {
 		r := <-data
 		if r.Err != nil {

--- a/examples/comment/main.go
+++ b/examples/comment/main.go
@@ -36,7 +36,7 @@ func main() {
 		panic(err)
 	}
 
-	data := client.IterComments(ctx, featured.Items[0].ID)
+	data := client.IterCommentsRoots(ctx, featured.Items[0].ID)
 	for i := 0; i < 60; i++ {
 		r := <-data
 		if r.Err != nil {

--- a/examples/comment/main.go
+++ b/examples/comment/main.go
@@ -20,7 +20,7 @@ func printComment(c *ifunny.Comment) {
 func main() {
 	ctx := context.Background()
 	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
-	comments, err := client.GetCommentPage(ctx, compose.Comments("r4mB8i4NA").Request(compose.NoPage()))
+	comments, err := ifunny.FetchPage[ifunny.CommentsEnvelope](ctx, client, compose.Comments("r4mB8i4NA").Request(compose.NoPage()))
 	if err != nil {
 		panic(err)
 	}
@@ -31,7 +31,7 @@ func main() {
 
 	featuredFeed := compose.NamedFeed("featured")
 	featuredFeed.Limit = 1
-	featured, err := client.GetFeedPage(ctx, featuredFeed.Request(compose.NoPage()))
+	featured, err := ifunny.FetchPage[ifunny.FeedEnvelope](ctx, client, featuredFeed.Request(compose.NoPage()))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/content/main.go
+++ b/examples/content/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	feed := compose.NamedFeed("featured")
 	feed.Limit = 5
-	page, err := client.GetFeedPage(ctx, feed.Request(compose.NoPage()))
+	page, err := ifunny.FetchPage[ifunny.FeedEnvelope](ctx, client, feed.Request(compose.NoPage()))
 	if err != nil {
 		panic(err)
 	}
@@ -43,7 +43,7 @@ func main() {
 		fmt.Println("that was the end of the feed")
 	}
 
-	page, err = client.GetFeedPage(ctx, feed.Request(compose.Next(compose.Literal{Wrapped: page.Paging.Cursors.Next})))
+	page, err = ifunny.FetchPage[ifunny.FeedEnvelope](ctx, client, feed.Request(compose.Next(compose.Literal{Wrapped: page.Paging.Cursors.Next})))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/explore/main.go
+++ b/examples/explore/main.go
@@ -25,7 +25,7 @@ func main() {
 	ctx := context.Background()
 	client, _ := ifunny.MakeClient(ctx, bearer, ifunny.RawUserAgent(userAgent))
 
-	page, err := client.ExploreContentPage(ctx, compose.Explore("content_shuffle").Request(compose.NoPage()))
+	page, err := ifunny.FetchPage[ifunny.ExploreEnvelope[ifunny.Content]](ctx, client, compose.Explore("content_shuffle").Request(compose.NoPage()))
 	if err != nil {
 		panic(err)
 	}

--- a/explore.go
+++ b/explore.go
@@ -6,62 +6,35 @@ import (
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
-func explorePage[T Content | User | ChatChannel](ctx context.Context, client *Client, request compose.Request) (*Page[T], error) {
-	content := new(struct {
-		Data struct {
-			Value struct {
-				Context Page[T] `json:"context"`
-			} `json:"value"`
-		} `json:"data"`
-	})
-
-	err := client.RequestJSON(ctx, request, content)
-	return &content.Data.Value.Context, err
+// ExploreEnvelope is the response envelope shared by every explore compilation:
+// the page lives at data.value.context. Unlike the per-type feed envelopes, one
+// explore endpoint serves several item types (content, users, chat channels), so
+// this envelope is generic over T — pick the item type when naming it, e.g.
+// ExploreEnvelope[Content]. Hand it to [FetchPage]/[Iter] as E.
+type ExploreEnvelope[T Content | User | ChatChannel] struct {
+	Data struct {
+		Value struct {
+			Context Page[T] `json:"context"`
+		} `json:"value"`
+	} `json:"data"`
 }
 
-// ExploreContentPage fetches a single page of explore content given a composed request.
-// It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreContentPage(ctx context.Context, requet compose.Request) (*Page[Content], error) {
-	return explorePage[Content](ctx, client, requet)
-}
-
-// ExploreUserPage fetches a single page of explore users given a composed request.
-// It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreUserPage(ctx context.Context, requet compose.Request) (*Page[User], error) {
-	return explorePage[User](ctx, client, requet)
-}
-
-// ExploreChatChannelPage fetches a single page of explore chat channels given a composed request.
-// It is used internally by explore iteration methods and exported for advanced use cases.
-func (client *Client) ExploreChatChannelPage(ctx context.Context, requet compose.Request) (*Page[ChatChannel], error) {
-	return explorePage[ChatChannel](ctx, client, requet)
-}
-
-func iterExplore[T Content | User | ChatChannel](ctx context.Context, client *Client, compilation string) <-chan Result[*T] {
-	return iterFrom(
-		ctx,
-		client,
-		compose.Explore(compilation),
-		func(ctx context.Context, request compose.Request) (*Page[T], error) {
-			return explorePage[T](ctx, client, request)
-		},
-	)
-}
+func (e ExploreEnvelope[T]) page() Page[T] { return e.Data.Value.Context }
 
 // IterExploreContent returns a channel that yields content from an explore compilation.
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreContent(ctx context.Context, compilation string) <-chan Result[*Content] {
-	return iterExplore[Content](ctx, client, compilation)
+	return Iter[ExploreEnvelope[Content]](ctx, client, compose.Explore(compilation))
 }
 
 // IterExploreUser returns a channel that yields users from an explore compilation.
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreUser(ctx context.Context, compilation string) <-chan Result[*User] {
-	return iterExplore[User](ctx, client, compilation)
+	return Iter[ExploreEnvelope[User]](ctx, client, compose.Explore(compilation))
 }
 
 // IterExploreChatChannel returns a channel that yields chat channels from an explore compilation.
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterExploreChatChannel(ctx context.Context, compilation string) <-chan Result[*ChatChannel] {
-	return iterExplore[ChatChannel](ctx, client, compilation)
+	return Iter[ExploreEnvelope[ChatChannel]](ctx, client, compose.Explore(compilation))
 }

--- a/iter.go
+++ b/iter.go
@@ -26,15 +26,41 @@ type Result[T any] struct {
 	Err error
 }
 
-// Iterator is a convenience wrapper around a channel of Results. It holds functions
-// to obtain the result channel (Iter) and to stop iteration early (Stop). Not
-// currently used by the root package; it is available for future use or custom iterators.
-type Iterator[T any] struct {
-	Iter func() <-chan Result[T]
-	Stop func()
+// pageOf is any API response envelope that carries a [Page] of T. Each paginated
+// endpoint family wraps its page in a different JSON shape (feeds under
+// data.content, explore under data.value.context, subscribers under data.users,
+// and so on); the envelope type is the single place that knows where its page
+// lives. page returns the whole [Page] — items and the paging [Cursor] together —
+// so the pagination token every feed relies on to advance rides along with the
+// items rather than needing a second, envelope-specific accessor.
+type pageOf[T Comment | Content | User | ChatChannel] interface {
+	page() Page[T]
 }
 
-func iterFrom[T Content | Comment | User | ChatChannel](ctx context.Context, client *Client, feed compose.Feed, feeder func(context.Context, compose.Request) (*Page[T], error)) <-chan Result[*T] {
+// FetchPage fetches and decodes one page from request. The response envelope is
+// selected by the type argument E: FetchPage[FeedEnvelope] for a data.content
+// feed, FetchPage[ExploreEnvelope[Content]] for an explore compilation,
+// FetchPage[UsersEnvelope] for a subscriber list, and so on. T is inferred from
+// E, so only the envelope need be named at the call site.
+func FetchPage[E pageOf[T], T Comment | Content | User | ChatChannel](ctx context.Context, client *Client, request compose.Request) (*Page[T], error) {
+	var env E
+	if err := client.RequestJSON(ctx, request, &env); err != nil {
+		return nil, err
+	}
+	page := env.page()
+	return &page, nil
+}
+
+// Iter drives pagination over feed, decoding each page with the envelope named
+// by E, and returns a channel of Results yielding *T. It is the generic engine
+// behind IterContent, IterExploreContent, IterSubscribers and the rest, and the
+// public escape hatch for iterating any feed descriptor against any known
+// envelope — e.g. Iter[FeedEnvelope](ctx, client, compose.NamedFeed("featured")).
+//
+// Pagination follows the server's cursor (each page's Paging), transformed by
+// feed.Pager and seeded by feed.Seed. Cancel ctx to stop; see [Result] for the
+// channel-close and cancellation contract.
+func Iter[E pageOf[T], T Content | Comment | User | ChatChannel](ctx context.Context, client *Client, feed compose.Feed) <-chan Result[*T] {
 	page := feed.Seed
 	data := make(chan Result[*T])
 
@@ -65,7 +91,7 @@ func iterFrom[T Content | Comment | User | ChatChannel](ctx context.Context, cli
 		defer close(data)
 		for {
 			log.Trace("buffering a feed page")
-			items, err := feeder(ctx, feed.Request(page))
+			items, err := FetchPage[E](ctx, client, feed.Request(page))
 			if err != nil {
 				log.Trace("failed to get a feed page, exiting")
 				send(Result[*T]{Err: err})

--- a/iter_test.go
+++ b/iter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/open-ifunny/ifunny-go/compose"
 )
 
-// feedPageJSON is a GetFeedPage-shaped response with two items and hasNext=true,
+// feedPageJSON is a FeedEnvelope-shaped response with two items and hasNext=true,
 // so an iterator against it pages forever until stopped.
 const feedPageJSON = `{"data":{"content":{"items":[{"id":"a"},{"id":"b"}],"paging":{"cursors":{"next":"n"},"hasNext":true}}}}`
 

--- a/pageable_test.go
+++ b/pageable_test.go
@@ -1,0 +1,80 @@
+package ifunny
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/open-ifunny/ifunny-go/compose"
+)
+
+// TestFetchPage_SelectsEnvelope confirms the envelope type argument, not the item
+// type, decides where the Page is read from: the same Content lands under
+// data.content for a feed and under data.value.context for an explore compilation.
+func TestFetchPage_SelectsEnvelope(t *testing.T) {
+	const feedJSON = `{"data":{"content":{"items":[{"id":"feed-a"}],"paging":{"cursors":{"next":"n"},"hasNext":true}}}}`
+	const explJSON = `{"data":{"value":{"context":{"items":[{"id":"expl-a"}],"paging":{"cursors":{"next":"m"},"hasNext":false}}}}}`
+
+	t.Run("feed envelope", func(t *testing.T) {
+		client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(feedJSON))
+		})
+		page, err := FetchPage[FeedEnvelope](context.Background(), client, compose.NamedFeed("featured").Request(compose.NoPage()))
+		if err != nil {
+			t.Fatalf("FetchPage: %v", err)
+		}
+		if len(page.Items) != 1 || page.Items[0].ID != "feed-a" {
+			t.Fatalf("items: %+v", page.Items)
+		}
+		if page.Paging.Cursors.Next != "n" || !page.Paging.HasNext {
+			t.Fatalf("paging not decoded: %+v", page.Paging)
+		}
+	})
+
+	t.Run("explore envelope", func(t *testing.T) {
+		client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(explJSON))
+		})
+		page, err := FetchPage[ExploreEnvelope[Content]](context.Background(), client, compose.Explore("content_shuffle").Request(compose.NoPage()))
+		if err != nil {
+			t.Fatalf("FetchPage: %v", err)
+		}
+		if len(page.Items) != 1 || page.Items[0].ID != "expl-a" {
+			t.Fatalf("items: %+v", page.Items)
+		}
+	})
+}
+
+// TestIter_ThreadsPagingToken drives Iter over an explore envelope across two
+// pages and asserts the server-returned cursor is sent back on the next request —
+// i.e. the paging token every feed relies on rides through the generic engine via
+// the envelope's page().Paging.
+func TestIter_ThreadsPagingToken(t *testing.T) {
+	var secondReqCursor string
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("next") {
+		case "":
+			// page 1: one item, hand back a cursor and promise more
+			w.Write([]byte(`{"data":{"value":{"context":{"items":[{"id":"p1"}],"paging":{"cursors":{"next":"CUR1"},"hasNext":true}}}}}`))
+		default:
+			secondReqCursor = r.URL.Query().Get("next")
+			// page 2: last item, stop
+			w.Write([]byte(`{"data":{"value":{"context":{"items":[{"id":"p2"}],"paging":{"cursors":{},"hasNext":false}}}}}`))
+		}
+	})
+
+	var ids []string
+	for r := range Iter[ExploreEnvelope[Content]](context.Background(), client, compose.Explore("content_shuffle")) {
+		if r.Err != nil {
+			t.Fatalf("Iter: %v", r.Err)
+		}
+		ids = append(ids, r.V.ID)
+	}
+
+	if len(ids) != 2 || ids[0] != "p1" || ids[1] != "p2" {
+		t.Fatalf("ids across pages: got %v, want [p1 p2]", ids)
+	}
+	if secondReqCursor != "CUR1" {
+		t.Fatalf("page 2 cursor: got %q, want CUR1 (paging token did not thread through Iter)", secondReqCursor)
+	}
+}

--- a/user.go
+++ b/user.go
@@ -51,32 +51,29 @@ func (client *Client) GetUser(ctx context.Context, desc compose.Request) (*User,
 	return &user.Data, err
 }
 
-// GetUsersPage fetches a page of users from endpoints whose envelope is data.users
-// (e.g., content smiles, content republishers, user subscribers, subscriptions).
-// It is used internally by user iteration methods and exported for advanced use cases.
-// These endpoints return a reduced projection of User (no email/privacy fields);
-// absent fields are simply zero-valued.
-func (client *Client) GetUsersPage(ctx context.Context, request compose.Request) (*Page[User], error) {
-	users := new(struct {
-		Data struct {
-			Users Page[User] `json:"users"`
-		} `json:"data"`
-	})
-
-	err := client.RequestJSON(ctx, request, users)
-	return &users.Data.Users, err
+// UsersEnvelope is the response envelope for user feeds whose page lives at
+// data.users (content smiles, content republishers, user subscribers,
+// subscriptions). Hand it to [FetchPage]/[Iter] as E. These endpoints return a
+// reduced projection of User (no email/privacy fields); absent fields are simply
+// zero-valued.
+type UsersEnvelope struct {
+	Data struct {
+		Users Page[User] `json:"users"`
+	} `json:"data"`
 }
+
+func (e UsersEnvelope) page() Page[User] { return e.Data.Users }
 
 // IterSubscribers returns a channel that yields users who follow the user (identified by ID).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterSubscribers(ctx context.Context, id string) <-chan Result[*User] {
-	return iterFrom(ctx, client, compose.Subscribers(id), client.GetUsersPage)
+	return Iter[UsersEnvelope](ctx, client, compose.Subscribers(id))
 }
 
 // IterSubscriptions returns a channel that yields users followed by the user (identified by ID).
 // The iterator automatically fetches new pages as needed.
 func (client *Client) IterSubscriptions(ctx context.Context, id string) <-chan Result[*User] {
-	return iterFrom(ctx, client, compose.Subscriptions(id), client.GetUsersPage)
+	return Iter[UsersEnvelope](ctx, client, compose.Subscriptions(id))
 }
 
 // GetUsers executes a chat RPC call and unmarshals the result as a list of users.


### PR DESCRIPTION
## Summary
- Collapse eight hand-rolled `Get*Page`/`iterExplore` feeders into six three-line envelope types plus two generics (`FetchPage[E]`, `Iter[E]`).
- Each paginated endpoint family declares its response shape once via a `pageOf[T]` envelope whose `page()` returns the whole `Page[T]` — items **and** paging cursor together — so the pagination token threads through the generic engine.
- Convenience `Iter*` methods become one-liners; the dead `Iterator[T]` type is removed. Net simplification with fuller docs.

The envelope, not the item type, decides where the page is read from — the same `Content` is served under `data.content` (feeds) and `data.value.context` (explore):

| Envelope | Page path |
|---|---|
| `FeedEnvelope` | `data.content` |
| `ExploreEnvelope[T]` | `data.value.context` |
| `UsersEnvelope` | `data.users` |
| `CommentsEnvelope` | `data.comments` |
| `RepliesEnvelope` | `data.replies` |
| `ChannelsEnvelope` | `data.channels` |

Escape hatch for iterating any feed against any known envelope:
```go
Iter[FeedEnvelope](ctx, client, compose.NamedFeed("featured"))
Iter[ExploreEnvelope[Content]](ctx, client, compose.Explore("content_shuffle"))
page, err := FetchPage[FeedEnvelope](ctx, client, feed.Request(compose.NoPage()))
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (green, incl. new `pageable_test.go`)
- [ ] `TestFetchPage_SelectsEnvelope` — same `Content` decoded from `data.content` vs `data.value.context` by envelope arg
- [ ] `TestIter_ThreadsPagingToken` — server cursor `CUR1` resent on page 2, confirming paging tokens thread through the generic engine